### PR TITLE
Refactor core functions to enable thread-safety in the API

### DIFF
--- a/neovim/buffer.py
+++ b/neovim/buffer.py
@@ -1,6 +1,13 @@
 from util import RemoteMap
 
 class Buffer(object):
+    @classmethod
+    def initialize(self, buffer):
+        buffer.vars = RemoteMap(lambda k: buffer.get_var(k),
+                                lambda k, v: buffer.set_var(k, v))
+        buffer.options = RemoteMap(lambda k: buffer.get_option(k),
+                                   lambda k, v: buffer.set_option(k, v))
+
     def __len__(self):
         return self.get_length()
 
@@ -61,20 +68,6 @@ class Buffer(object):
     @property
     def number(self):
         return self.get_number()
-
-    @property
-    def vars(self):
-        if not hasattr(self, '_vars'):
-            self._vars = RemoteMap(lambda k: self.get_var(k),
-                                   lambda k, v: self.set_var(k, v))
-        return self._vars
-
-    @property
-    def options(self):
-        if not hasattr(self, '_options'):
-            self._options = RemoteMap(lambda k: self.get_option(k),
-                                      lambda k, v: self.set_option(k, v))
-        return self._options
 
     @property
     def valid(self):

--- a/neovim/tabpage.py
+++ b/neovim/tabpage.py
@@ -1,20 +1,13 @@
 from util import RemoteMap, RemoteSequence
 
 class Tabpage(object):
-    @property
-    def windows(self):
-        if not hasattr(self, '_windows'):
-            self._windows = RemoteSequence(self,
-                                           self._vim.Window,
-                                           lambda: self.get_windows())
-        return self._windows
-
-    @property
-    def vars(self):
-        if not hasattr(self, '_vars'):
-            self._vars = RemoteMap(lambda k: self.get_var(k),
-                                   lambda k, v: self.set_var(k, v))
-        return self._vars
+    @classmethod
+    def initialize(self, tabpage):
+        tabpage.windows = RemoteSequence(tabpage._vim,
+                                         tabpage._vim.Window,
+                                         lambda: tabpage.get_windows())
+        tabpage.vars = RemoteMap(lambda k: tabpage.get_var(k),
+                                 lambda k, v: tabpage.set_var(k, v))
 
     @property
     def number(self):

--- a/neovim/util.py
+++ b/neovim/util.py
@@ -1,7 +1,12 @@
 class RemoteSequence(object):
     # TODO Need to add better support for this class on the server
     def __init__(self, vim, remote_klass, handle_array_fn):
-        self._wrap_fn = lambda handle: remote_klass(vim, handle)
+        def wrap(handle):
+            rv = remote_klass(vim, handle)
+            remote_klass.initialize(rv)
+            return rv
+
+        self._wrap_fn = wrap
         self._handle_array_fn = handle_array_fn
 
     def __len__(self):
@@ -11,7 +16,6 @@ class RemoteSequence(object):
         if not isinstance(idx, slice):
             return self._wrap_fn(self._handle_array_fn()[idx])
         return map(self._wrap_fn, self._handle_array_fn()[idx.start:idx.stop])
-
 
     def __iter__(self):
         handles = self._handle_array_fn()

--- a/neovim/vim.py
+++ b/neovim/vim.py
@@ -6,6 +6,25 @@ os_fchdir = os.fchdir
 
 
 class Vim(object):
+    @classmethod
+    def initialize(self, vim, classes, channel_id):
+        vim.buffers = RemoteSequence(vim,
+                                     classes['buffer'],
+                                     lambda: vim.get_buffers())
+        vim.windows = RemoteSequence(vim,
+                                     classes['window'],
+                                     lambda: vim.get_windows())
+        vim.tabpages = RemoteSequence(vim,
+                                      classes['tabpage'],
+                                      lambda: vim.get_tabpages())
+        vim.current = Current(vim)
+        vim.vars = RemoteMap(lambda k: vim.get_var(k),
+                             lambda k, v: vim.set_var(k, v))
+        vim.vvars = RemoteMap(lambda k: vim.get_vvar(k),
+                              None)
+        vim.options = RemoteMap(lambda k: vim.get_option(k),
+                                lambda k, v: vim.set_option(k, v))
+        vim.channel_id = channel_id
 
     def foreach_rtp(self, cb):
         """
@@ -34,54 +53,3 @@ class Vim(object):
         """
         os_fchdir(dir_fd)
         self.change_directory(os.getcwd())
-
-    @property
-    def buffers(self):
-        if not hasattr(self, '_buffers'):
-            self._buffers = RemoteSequence(self,
-                                           self.Buffer,
-                                           lambda: self.get_buffers())
-        return self._buffers
-
-    @property
-    def windows(self):
-        if not hasattr(self, '_windows'):
-            self._windows = RemoteSequence(self,
-                                           self.Window,
-                                           lambda: self.get_windows())
-        return self._windows
-
-    @property
-    def tabpages(self):
-        if not hasattr(self, '_tabpages'):
-            self._tabpages = RemoteSequence(self,
-                                            self.Tabpage,
-                                            lambda: self.get_tabpages())
-        return self._tabpages
-
-    @property
-    def current(self):
-        if not hasattr(self, '_current'):
-            self._current = Current(self)
-        return self._current
-
-    @property
-    def vars(self):
-        if not hasattr(self, '_vars'):
-            self._vars = RemoteMap(lambda k: self.get_var(k),
-                                   lambda k, v: self.set_var(k, v))
-        return self._vars
-
-    @property
-    def vvars(self):
-        if not hasattr(self, '_vvars'):
-            self._vvars = RemoteMap(lambda k: self.get_vvar(k),
-                                    None)
-        return self._vvars
-
-    @property
-    def options(self):
-        if not hasattr(self, '_options'):
-            self._options = RemoteMap(lambda k: self.get_option(k),
-                                      lambda k, v: self.set_option(k, v))
-        return self._options

--- a/neovim/window.py
+++ b/neovim/window.py
@@ -1,6 +1,13 @@
 from util import RemoteMap
 
 class Window(object):
+    @classmethod
+    def initialize(self, window):
+        window.vars = RemoteMap(lambda k: window.get_var(k),
+                                lambda k, v: window.set_var(k, v))
+        window.options = RemoteMap(lambda k: window.get_option(k),
+                                   lambda k, v: window.set_option(k, v))
+
     @property
     def buffer(self):
         return self.get_buffer()
@@ -28,20 +35,6 @@ class Window(object):
     @width.setter
     def width(self, width):
         self.set_width(width)
-
-    @property
-    def vars(self):
-        if not hasattr(self, '_vars'):
-            self._vars = RemoteMap(lambda k: self.get_var(k),
-                                   lambda k, v: self.set_var(k, v))
-        return self._vars
-
-    @property
-    def options(self):
-        if not hasattr(self, '_options'):
-            self._options = RemoteMap(lambda k: self.get_option(k),
-                                      lambda k, v: self.set_option(k, v))
-        return self._options
 
     @property
     def number(self):

--- a/test/test_concurrency.py
+++ b/test/test_concurrency.py
@@ -1,0 +1,32 @@
+from time import sleep
+from random import random
+from nose.tools import with_setup, eq_ as eq, ok_ as ok
+from common import vim, cleanup
+from threading import Thread
+
+
+@with_setup(setup=cleanup)
+def test_concurrent_calls():
+    vim.setup_done = True
+    def produce(i):
+        str = 'call send_event(%d, "integer", %d)' % (vim.channel_id, i,)
+        sleep(0.05 * random())
+        vim.command(str)
+
+    vim.subscribe('integer')
+
+    count = 50
+    for i in xrange(count):
+        t = Thread(target=produce, args=(i,))
+        t.daemon = True
+        t.start()
+
+    integers = []
+    while len(integers) < count:
+        integers.append(vim.next_event()[1])
+
+    vim.unsubscribe('integer')
+
+    for i in xrange(count):
+        ok(i in integers)
+


### PR DESCRIPTION
- Remove lazy initialization of helper properties
- Add 'interrupt' method to the stream class, which allows other threads to
  call API functions while another one is blocking on `next_event`
- Synchronize access to `next_event`/`msgpack_rpc_call`
