### PR TITLE
Add support for client-side RPC

### DIFF
--- a/test/test_buffer.py
+++ b/test/test_buffer.py
@@ -118,3 +118,12 @@ def test_mark():
     vim.current.window.cursor = [3, 4]
     vim.command('mark V')
     eq(vim.current.buffer.mark('V'), [3, 0])
+
+
+@with_setup(setup=cleanup)
+def test_get_exceptions():
+    try:
+        vim.current.buffer.options['invalid-option']
+        ok(False)
+    except vim.VimError:
+        pass

--- a/test/test_client_rpc.py
+++ b/test/test_client_rpc.py
@@ -1,0 +1,65 @@
+# -*- coding: utf-8 -*-
+import os
+from nose.tools import with_setup, eq_ as eq, ok_ as ok
+from common import vim, cleanup
+
+cid = vim.channel_id
+
+@with_setup(setup=cleanup)
+def test_call_and_reply():
+    cmd = 'let g:result = send_call(%d, "client-call", [1,2,3])' % cid
+    promise = vim.send_command(cmd)
+    call = vim.next_message()
+    eq(call.name, 'client-call')
+    eq(call.arg, [1, 2, 3])
+    call.reply([4, 5, 6])
+    promise.wait()
+    eq(vim.vars['result'], [4, 5, 6])
+
+
+@with_setup(setup=cleanup)
+def test_call_api_before_reply():
+    cmd = 'let g:result = send_call(%d, "client-call", [1,2,3])' % cid
+    promise = vim.send_command(cmd)
+    call = vim.next_message()
+    eq(call.arg, [1, 2, 3])
+    vim.command('let g:result2 = [7, 8, 9]')
+    call.reply(vim.vars['result2'])
+    promise.wait()
+    eq(vim.vars['result'], [7, 8, 9])
+
+
+@with_setup(setup=cleanup)
+def test_recursion():
+    vim.vars['result1'] = 0
+    vim.vars['result2'] = 0
+    vim.vars['result3'] = 0
+    vim.vars['result4'] = 0
+    cmd = 'let g:result1 = send_call(%d, "client-call", %d)' % (cid, 2,)
+    promise1 = vim.send_command(cmd)
+    call1 = vim.next_message()
+    arg = call1.arg * 2
+    cmd = 'let g:result2 = send_call(%d, "client-call", %d)' % (cid, arg,)
+    promise2 = vim.send_command(cmd)
+    call2 = vim.next_message()
+    arg = call2.arg * 2
+    cmd = 'let g:result3 = send_call(%d, "client-call", %d)' % (cid, arg,)
+    promise3 = vim.send_command(cmd)
+    call3 = vim.next_message()
+    arg = call3.arg * 2
+    cmd = 'let g:result4 = send_call(%d, "client-call", %d)' % (cid, arg,)
+    promise3 = vim.send_command(cmd)
+    call4 = vim.next_message()
+    # start responding the calls and asserting variable values
+    eq(vim.vars['result4'], 0)
+    call4.reply(call4.arg)
+    eq(vim.vars['result4'], 16)
+    eq(vim.vars['result3'], 0)
+    call3.reply(call3.arg)
+    eq(vim.vars['result3'], 8)
+    eq(vim.vars['result2'], 0)
+    call2.reply(call2.arg)
+    eq(vim.vars['result2'], 4)
+    eq(vim.vars['result1'], 0)
+    call1.reply(call1.arg)
+    eq(vim.vars['result1'], 2)

--- a/test/test_concurrency.py
+++ b/test/test_concurrency.py
@@ -20,20 +20,20 @@ def test_concurrent_calls():
 
     integers = []
     while len(integers) < count:
-        integers.append(vim.next_event()[1])
+        integers.append(vim.next_message().arg)
 
     for i in xrange(count):
         ok(i in integers)
 
 
 @with_setup(setup=cleanup)
-def test_custom_events():
+def test_custom_messages():
     def produce(i):
         if i % 2 == 0:
-            str = 'call send_event(%d, "nvim-event", 0)' % (vim.channel_id)
+            str = 'call send_event(%d, "nvim-message", 0)' % (vim.channel_id)
             vim.command(str)
         else:
-            vim.push_event('custom-event', None)
+            vim.push_message('custom-message', None)
         sleep(0.05 * random())
 
     count = 50
@@ -42,14 +42,14 @@ def test_custom_events():
         t.daemon = True
         t.start()
 
-    nvim_events = []
-    custom_events = []
-    while len(nvim_events) < 25 or len(custom_events) < 25 :
-        event = vim.next_event()
-        if event[0] == 'nvim-event':
-            nvim_events.append(event)
-        elif event[0] == 'custom-event':
-            custom_events.append(event)
+    nvim_messages = []
+    custom_messages = []
+    while len(nvim_messages) < 25 or len(custom_messages) < 25 :
+        message = vim.next_message()
+        if message.name == 'nvim-message':
+            nvim_messages.append(message)
+        elif message.name == 'custom-message':
+            custom_messages.append(message)
 
-    eq(len(nvim_events), 25)
-    eq(len(custom_events), 25)
+    eq(len(nvim_messages), 25)
+    eq(len(custom_messages), 25)

--- a/test/test_events.py
+++ b/test/test_events.py
@@ -7,13 +7,15 @@ from common import vim, cleanup
 @with_setup(setup=cleanup)
 def test_receiving_events():
     vim.command('call send_event(%d, "test-event", [1,2,3])' % vim.channel_id)
-    events = vim.expect('test-event', lambda e: set(e[1]) == set([1, 2, 3]))
-    eq(events, [['test-event', [1, 2, 3]]])
+    event = vim.next_message()
+    eq(event.name, 'test-event')
+    eq(event.arg, [1, 2, 3])
     vim.command('au FileType python call send_event(%d, "py!", bufnr("$"))' %
                 vim.channel_id)
     vim.command('set filetype=python')
-    events = vim.expect('py!', lambda e: e[1] == vim.current.buffer.number)
-    eq(events, [['py!', vim.current.buffer.number]])
+    event = vim.next_message()
+    eq(event.name, 'py!')
+    eq(event.arg, vim.current.buffer.number)
 
 
 @with_setup(setup=cleanup)
@@ -22,12 +24,18 @@ def test_broadcast():
     vim.command('call send_event(0, "event1", [1,2,3])')
     vim.command('call send_event(0, "event2", [4,5,6])')
     vim.command('call send_event(0, "event2", [7,8,9])')
-    events = vim.expect('event2', 2, lambda e: e[1][0] == 7)
-    eq(events, [['event2', [4, 5, 6]], ['event2', [7, 8, 9]]])
+    event = vim.next_message()
+    eq(event.name, 'event2')
+    eq(event.arg, [4, 5, 6])
+    event = vim.next_message()
+    eq(event.name, 'event2')
+    eq(event.arg, [7, 8, 9])
     vim.unsubscribe('event2')
     vim.subscribe('event1')
     vim.command('call send_event(0, "event2", [10,11,12])')
     vim.command('call send_event(0, "event1", [13,14,15])')
-    eq(vim.next_event(), ['event1', [13, 14, 15]])
+    msg = vim.next_message()
+    eq(msg.name, 'event1')
+    eq(msg.arg, [13, 14, 15])
 
 


### PR DESCRIPTION
A major refactor was necessary in order to support client-side RPC:
- Every API function now has a non-blocking variant(prefixed with `send_`).
  These send_\* functions return promises that have a single `wait` method to
  wait for the result.
- The synchronous versions are still provided, but are implemented by calling
  the async version followed by a `wait` call.
- `vim.next_event` is now `vim.next_message`, and messages are specialized
  objects that represent events or requests. It always has at least three
  properties: `name`, `args` and `type` where:
  - `name` is the method/event name
  - `args` is the method/event arguments
  - `type` is either `event` or `request`
    Additionally, requests have a `reply` method that can be used respond to the
    request. The `reply` method accepts a single argument that will be returned
    to the remote nvim instance.
- `vim.push_event` is now `vim.push_message` and receives two arguments: `name`
  and `args`.
- Multi-thread synchronization was refactored/improved

On top of that, the `expect` method was removed since that can be easily
implemented as a higher-level feature of a test library.
