### PR TITLE
Expect vi 'compatible' option to be false

### DIFF
--- a/test/test_vim.py
+++ b/test/test_vim.py
@@ -68,8 +68,6 @@ def test_vars():
 
 @with_setup(setup=cleanup)
 def test_options():
-    eq(vim.options['compatible'], True)
-    vim.options['compatible'] = False
     eq(vim.options['compatible'], False)
 
 


### PR DESCRIPTION
The https://github.com/neovim/neovim/pull/926 changes vi compatibility
to false.
