### PR TITLE
[RDY] RemoteMap: add 'get' method

### DIFF
--- a/neovim/api/common.py
+++ b/neovim/api/common.py
@@ -58,6 +58,13 @@ class RemoteMap(object):
         except:
             return False
 
+    def get(self, key, default=None):
+        """Return value for key if present, else a default value."""
+        try:
+            return self._get(key)
+        except:
+            return default
+
 
 class RemoteSequence(object):
 


### PR DESCRIPTION
I often stumble on this one, as (I think) it's a common pattern to get a user specified option variable with a default value, for instance:

```
 if self.vim.vars.get('myplugin_some_bool_option'): #defaults to None (which is false)
    # do stuff,

```

The more fullblown alternative would be to use `UserDict.DictMixin`, if one also wants to support iterators etc, but I think this is the most useful `dict`-method for the intented usage.
