### PR TITLE
Do not use bare `except:`.

### DIFF
--- a/neovim/api/common.py
+++ b/neovim/api/common.py
@@ -55,14 +55,14 @@ class RemoteMap(object):
         try:
             self._get(key)
             return True
-        except:
+        except Exception:
             return False
 
     def get(self, key, default=None):
         """Return value for key if present, else a default value."""
         try:
             return self._get(key)
-        except:
+        except Exception:
             return default
 
 

--- a/neovim/api/nvim.py
+++ b/neovim/api/nvim.py
@@ -126,7 +126,7 @@ class Nvim(object):
             try:
                 if cb(path) is not None:
                     break
-            except:
+            except Exception:
                 break
 
     def chdir(self, dir_path):

--- a/neovim/plugins/plugin_host.py
+++ b/neovim/plugins/plugin_host.py
@@ -77,7 +77,7 @@ class PluginHost(object):
                 loaded.add(name)
                 try:
                     discovered = find_module(name, [directory])
-                except:
+                except Exception:
                     err_str = format_exc(5)
                     warn('error while searching module %s: %s', name, err_str)
                     continue
@@ -90,7 +90,7 @@ class PluginHost(object):
                         if name.startswith('Nvim'):
                             self.discovered_plugins.append(value)
                     debug('loaded %s', name)
-                except:
+                except Exception:
                     err_str = format_exc(5)
                     warn('error while loading module %s: %s', name, err_str)
                     continue
@@ -107,7 +107,7 @@ class PluginHost(object):
             debug('inspecting class %s', plugin_class.__name__)
             try:
                 plugin = plugin_class(self.nvim)
-            except:
+            except Exception:
                 err_str = format_exc(5)
                 warn('constructor for %s failed: %s', cls_name, err_str)
                 continue


### PR DESCRIPTION
> Because `except:` catches all exceptions, including `SystemExit`, `KeyboardInterrupt`, and `GeneratorExit` (which is not an error and should not normally be caught by user code), using a bare `except:` is almost never a good idea. In situations where you need to catch all “normal” errors, such as in a framework that runs callbacks, you can catch the base class for all normal exceptions, `Exception`.

https://docs.python.org/3/howto/doanddont.html#except
