### PR TITLE
Use &encoding for msgpack Packer

### DIFF
--- a/neovim/api/nvim.py
+++ b/neovim/api/nvim.py
@@ -44,7 +44,10 @@ class Nvim(object):
         creating specialized objects from Nvim remote handles.
         """
         session.error_wrapper = lambda e: NvimError(e[1])
-        channel_id, metadata = session.request('vim_get_api_info')
+        channel_id, metadata = session.request(b'vim_get_api_info')
+
+        encoding = session.request(b'vim_get_option', b'encoding')
+        session._async_session._msgpack_stream.set_packer_encoding(encoding)
 
         if IS_PYTHON3:
             hook = DecodeHook()

--- a/neovim/msgpack_rpc/msgpack_stream.py
+++ b/neovim/msgpack_rpc/msgpack_stream.py
@@ -21,10 +21,14 @@ class MsgpackStream(object):
         """Wrap `event_loop` on a msgpack-aware interface."""
         self._event_loop = event_loop
         self._posted = deque()
-        self._packer = Packer(use_bin_type=True)
+        self._packer = Packer(use_bin_type=True, encoding=None)
         self._unpacker = Unpacker()
         self._message_cb = None
         self._stopped = False
+
+    def set_packer_encoding(self, encoding):
+        """Switch encoding for Unicode strings."""
+        self._packer = Packer(use_bin_type=True, encoding=encoding)
 
     def post(self, msg):
         """Post `msg` to the read queue of the `MsgpackStream` instance.


### PR DESCRIPTION
- This commit disables automatic encoding of Unicode strings until
  &encoding is retrieved, and then resets the packer to use &encoding
- Previously the msgpack Packer always encoded Unicode as utf-8

I have not checked, but I think this was working previously and regressed. Basically this example should use &encoding instead of utf8

```
vim.current.line = u'¬'
```

This follows from #41. But it is not python3 specific.
