### PR TITLE
[RFC] Run flake8 after unit tests on Travis.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -29,10 +29,9 @@ install:
   - export PKG_CONFIG_PATH="$prefix/usr/lib/pkgconfig"
   - export USE_BUNDLED_DEPS=OFF
   - cd nvim && make && cd ..
-before_script:
-  - flake8 --exclude ./neovim/plugins neovim
 script:
   - ./nvim/scripts/run-api-tests.exp "nosetests" "./nvim/build/bin/nvim -u NONE"
   - NVIM_SPAWN_ARGV='["./nvim/build/bin/nvim", "-u", "NONE", "--embed"]' nosetests
-after_success:
+  - flake8 --exclude ./neovim/plugins neovim
+after_script:
   - ocular


### PR DESCRIPTION
Currently, Travis builds [error out](https://travis-ci.org/neovim/python-client/builds/38350398) if there's a style guide violation. With this PR, Travis will still run tests and upload results to Scrutinizer.
