### PR TITLE
[RFC] Travis: Use Neovim nightly and separate flake jobs.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,33 +5,42 @@ env:
     - NOSE_VERBOSE=2
     - NOSE_WITH_COVERAGE=true
     - NOSE_COVER_PACKAGE=neovim
+  matrix:
+    - CI_TARGET=tests
+matrix:
+  include:
+    - python: 2.7
+      env: CI_TARGET=flake
+    - python: 3.4
+      env: CI_TARGET=flake
 python:
   # If the build matrix gets bigger, also update the number of runs
   # at the bottom of .scrutinizer.yml.
-  - "2.6"
-  - "2.7"
-  - "3.2"
-  - "3.3"
-  - "3.4"
-  - "pypy"
+  - 2.6
+  - 2.7
+  - 3.2
+  - 3.3
+  - 3.4
+  - pypy
 before_install:
-  - sudo apt-get update -qq
-  - sudo apt-get install expect -q
-  - git clone --depth=1 -b master git://github.com/neovim/neovim nvim
-  - sudo git clone --depth=1 git://github.com/neovim/deps /opt/neovim-deps
-  - pip install -q flake8 flake8-import-order flake8-docstrings pep8-naming
-  - pip install -q scrutinizer-ocular
+  - if [ $CI_TARGET = tests ]; then
+      sudo apt-get update -qq;
+      sudo apt-get install expect -q;
+      eval "$(curl -Ss https://raw.githubusercontent.com/neovim/bot-ci/master/scripts/travis-setup.sh) nightly-x64";
+      pip install -q scrutinizer-ocular;
+    else
+      pip install -q flake8 flake8-import-order flake8-docstrings pep8-naming;
+    fi
 install:
   - pip install .
-  - prefix="/opt/neovim-deps/64"
-  - eval $($prefix/usr/bin/luarocks path)
-  - export PATH="$prefix/usr/bin:$PATH"
-  - export PKG_CONFIG_PATH="$prefix/usr/lib/pkgconfig"
-  - export USE_BUNDLED_DEPS=OFF
-  - cd nvim && make && cd ..
 script:
-  - ./nvim/scripts/run-api-tests.exp "nosetests" "./nvim/build/bin/nvim -u NONE"
-  - NVIM_SPAWN_ARGV='["./nvim/build/bin/nvim", "-u", "NONE", "--embed"]' nosetests
-  - flake8 --exclude ./neovim/plugins neovim
+  - if [ $CI_TARGET = tests ]; then
+      ./scripts/run-api-tests.exp "nosetests" "nvim -u NONE";
+      NVIM_SPAWN_ARGV='["nvim", "-u", "NONE", "--embed"]' nosetests;
+    else
+      flake8 --exclude ./neovim/plugins neovim;
+    fi
 after_script:
-  - ocular
+  - if [ $CI_TARGET = tests ]; then
+      ocular;
+    fi

--- a/scripts/run-api-tests.exp
+++ b/scripts/run-api-tests.exp
@@ -1,0 +1,50 @@
+#!/usr/bin/env expect
+
+if {$argc < 2} {
+  puts "Need commands for running the tests and for starting nvim"
+  exit 1
+}
+
+set timeout 60
+set run_tests [split [lindex $argv 0] " "]
+set run_nvim [split [lindex $argv 1] " "]
+
+# don't echo to stdout
+log_user 0
+# set NVIM_LISTEN_ADDRESS, so nvim will listen on a known socket
+set env(NVIM_LISTEN_ADDRESS) "/tmp/nvim-[exec date +%s%N].sock"
+# start nvim
+spawn {*}$run_nvim
+# save the job descriptor
+set nvim_id $spawn_id
+# Reset function that can be invoked by test runners to put nvim in a cleaner
+# state
+send {
+:echo "read"."y"
+}
+# wait until nvim is ready
+expect "ready"
+# run tests
+spawn {*}$run_tests
+set tests_id $spawn_id
+set status 1
+# listen for test output in the background
+expect_background {
+  * {
+    # show test output to the user
+    send_user -- $expect_out(buffer)
+  }
+  eof {
+    # collect the exit status code
+    set spawn_id $tests_id
+    catch wait result
+    set status [lindex $result 3]
+    set spawn_id $nvim_id
+    # quit nvim
+    send ":qa!\r"
+  }
+}
+# switch back nvim and wait until it exits 
+set spawn_id $nvim_id
+expect eof
+exit $status


### PR DESCRIPTION
Testing the nightly build (neovim/bot-ci#25), which allows to run the Python tests without having to build Neovim first. The nightly is downloaded and set up by the script currently at https://raw.githubusercontent.com/fwalch/bot-ci/nightly-test/scripts/travis-setup.sh
