### PR TITLE
[RDY] Use $VIM in runtimepath test.

### DIFF
--- a/test/test_vim.py
+++ b/test/test_vim.py
@@ -34,21 +34,21 @@ def test_strwidth():
 @with_setup(setup=cleanup)
 def test_list_runtime_paths():
     # Is this the default runtime path list?
-    homedir = os.environ['HOME'] + '/.nvim'
+    homedir = os.path.join(os.environ['HOME'], '.nvim')
+    vimdir = vim.eval('$VIM')
     dflt_rtp = [
         homedir,
-        '/usr/local/share/nvim/vimfiles',
-        '/usr/local/share/nvim',
-        '/usr/local/share/nvim/vimfiles/after'
+        os.path.join(vimdir, 'vimfiles'),
+        vimdir,
+        os.path.join(vimdir, 'vimfiles', 'after')
     ]
     # If the runtime is installed the default path
     # is nvim/runtime
     dflt_rtp2 = list(dflt_rtp)
-    dflt_rtp2[2] += '/runtime'
+    dflt_rtp2[2] = os.path.join(dflt_rtp2[2], 'runtime')
 
     rtp = vim.list_runtime_paths()
     ok(rtp == dflt_rtp or rtp == dflt_rtp2)
-
 
 
 @with_setup(setup=cleanup)


### PR DESCRIPTION
Previously, the test would only work if Neovim was installed (or configured to be installed) into `/usr/local`.
