### PR TITLE
Implemented vim.current.range

### DIFF
--- a/neovim/api/nvim.py
+++ b/neovim/api/nvim.py
@@ -199,6 +199,7 @@ class Current(object):
 
     def __init__(self, session):
         self._session = session
+        self.range = None
 
     @property
     def line(self):


### PR DESCRIPTION
This is related to https://github.com/neovim/python-client/issues/35

Added arguments range_start and range_end to methods python_execute and python_execute_file. The changes are dependent on https://github.com/neovim/neovim/pull/1376
