### PR TITLE
Include base version for msgpack, because 0.3 doesn't work

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ import sys
 from setuptools import setup
 
 install_requires = [
-    'msgpack-python',
+    'msgpack-python>=0.4.0',
 ]
 
 if sys.version_info < (3, 4):


### PR DESCRIPTION
If I import neovim with less than version 0.4 of msgpack installed, I get this stack trace:

```
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/home/chartdev/venvs/chartio/local/lib/python2.7/site-packages/neovim/__init__.py", line 8, in <module>
    from .api import DecodeHook, Nvim, SessionHook
  File "/home/chartdev/venvs/chartio/local/lib/python2.7/site-packages/neovim/api/__init__.py", line 9, in <module>
    from .nvim import Nvim, NvimError
  File "/home/chartdev/venvs/chartio/local/lib/python2.7/site-packages/neovim/api/nvim.py", line 4, in <module>
    from msgpack import ExtType
ImportError: cannot import name ExtType
```

0.4.0 seems to work.
