### PR TITLE
[RFC] Show more information about problems in plugins being loaded.

### DIFF
--- a/neovim/plugin/host.py
+++ b/neovim/plugin/host.py
@@ -13,7 +13,8 @@ from ..compat import IS_PYTHON3, find_module
 __all__ = ('Host')
 
 logger = logging.getLogger(__name__)
-debug, info, warn = (logger.debug, logger.info, logger.warn,)
+error, debug, info, warn = (logger.error, logger.debug, logger.info,
+                            logger.warn,)
 
 
 class Host(object):
@@ -77,7 +78,13 @@ class Host(object):
                 raise Exception('{0} is already loaded'.format(path))
             directory, name = os.path.split(os.path.splitext(path)[0])
             file, pathname, description = find_module(name, [directory])
-            module = imp.load_module(name, file, pathname, description)
+            try:
+                module = imp.load_module(name, file, pathname, description)
+            except ImportError:
+                error('Encountered import error loading plugin at %s' % path)
+            except Exception as e:
+                error('Error loading plugin at %s %s: %s' % (
+                    path, type(e).__name__, e))
             handlers = []
             self._discover_classes(module, handlers, path)
             self._discover_functions(module, handlers, path)


### PR DESCRIPTION
Show a useful error message when loading a plugin fails. Right now the python client dies silently if there are any problems in the plugin being loaded. Neovim itself still blows up in an ugly fashion, that probably requires a separate resolution.
