### PR TITLE
[RFC] Resolve file name and silent write.

### DIFF
--- a/test/test_buffer.py
+++ b/test/test_buffer.py
@@ -101,10 +101,10 @@ def test_number():
 def test_name():
     vim.command('new')
     eq(vim.current.buffer.name, '')
-    new_name = vim.eval('tempname()')
+    new_name = vim.eval('resolve(tempname())')
     vim.current.buffer.name = new_name
     eq(vim.current.buffer.name, new_name)
-    vim.command('w!')
+    vim.command('silent w!')
     ok(os.path.isfile(new_name))
     os.unlink(new_name)
 


### PR DESCRIPTION
This fixes symlink issues on OS X for /var and /private/var
It also stops vim.command('w!') from blocking.

This change fixes #66 
