### PR TITLE
[WIP/RFC] allow polling on a provided fd

### DIFF
--- a/neovim/msgpack_rpc/async_session.py
+++ b/neovim/msgpack_rpc/async_session.py
@@ -32,6 +32,10 @@ class AsyncSession(object):
         """Wrapper around `MsgpackStream.threadsafe_call`."""
         self._msgpack_stream.threadsafe_call(fn)
 
+    def poll_fd(self, fd, on_readable, on_writable):
+        """Wrapper around `BaseEventLoop.poll_fd`."""
+        return self._msgpack_stream.poll_fd(fd, on_readable, on_writable)
+
     def request(self, method, args, response_cb):
         """Send a msgpack-rpc request to Nvim.
 

--- a/neovim/msgpack_rpc/event_loop/asyncio.py
+++ b/neovim/msgpack_rpc/event_loop/asyncio.py
@@ -113,6 +113,18 @@ class AsyncioEventLoop(BaseEventLoop, asyncio.Protocol,
     def _threadsafe_call(self, fn):
         self._loop.call_soon_threadsafe(fn)
 
+    def _poll_fd(self, fd, on_readable, on_writable):
+        if on_readable is not None:
+            self._loop.add_reader(fd, on_readable)
+        if on_writable is not None:
+            self._loop.add_writer(fd, on_writable)
+        def cancel():
+            if on_readable is not None:
+                self._loop.remove_reader(fd)
+            if on_writable is not None:
+                self._loop.remove_writer(fd)
+        return cancel
+
     def _setup_signals(self, signals):
         if os.name == 'nt':
             # add_signal_handler is not supported in win32

--- a/neovim/msgpack_rpc/event_loop/base.py
+++ b/neovim/msgpack_rpc/event_loop/base.py
@@ -121,6 +121,24 @@ class BaseEventLoop(object):
         """
         self._threadsafe_call(fn)
 
+    def poll_fd(self, fd, on_readable=None, on_writable=None):
+        """
+        Invoke callbacks when the fd is ready for reading and/or writing. if
+        `on_readable` is not None, it should be callback, which will be invoked
+        (with no arguments) when the fd is ready for writing. Similarily if
+        `on_writable` is not None it will be invoked when the fd is ready for
+        writing.
+
+        Only one callback (of each kind) can be registered on the same fd at a
+        time. If both readability and writability should be monitored, both
+        callbacks must be registered by the same `poll_fd` call.
+
+        Returns a function that deactivates the callback(s).
+        """
+        if on_readable is None and on_writable is None:
+            raise ValueError("poll_fd: At least one of `on_readable` and `on_writable` must be present")
+        return self._poll_fd(fd, on_readable, on_writable)
+
     def run(self, data_cb):
         """Run the event loop."""
         if self._error:

--- a/neovim/msgpack_rpc/msgpack_stream.py
+++ b/neovim/msgpack_rpc/msgpack_stream.py
@@ -28,6 +28,10 @@ class MsgpackStream(object):
         """Wrapper around `BaseEventLoop.threadsafe_call`."""
         self._event_loop.threadsafe_call(fn)
 
+    def poll_fd(self, fd, on_readable, on_writable):
+        """Wrapper around `BaseEventLoop.poll_fd`."""
+        return self._event_loop.poll_fd(fd, on_readable, on_writable)
+
     def send(self, msg):
         """Queue `msg` for sending to Nvim."""
         debug('sent %s', msg)


### PR DESCRIPTION
This allows a plugin to poll for readability and/or writability on a specified fd. 
[here](https://gist.github.com/bfredl/5f90c9ebca958401b4ee) is an example integrating with a zeromq socket.

However, I'm not actually sure we want to spawn a greenlet for every poll event, because this event doesn't imply that there actually is useful data that needs to be handled. ( For instance, `zmq` uses the same fd also for internal communication with its worker threads and so at times there could be lots of spurious poll events) Perhaps its better to spawn a greenlet only when there is message, for instance:

```
     def _on_poll(self, fd, read, write):
        while self.sock.getsockopt(zmq.EVENTS) & zmq.POLLIN:
            self.vim.session.schedule(lambda: self.on_msg( self.sock.recv()))
```

One might even want back to yield back to an existing greenlet that is blocking on receiving (or sending) on the fd. 
Or it could be that spawning new greenlets is so cheap, that its not worth bothering avoiding it, I don't know.
