### PR TITLE
Add exc to first line of ErrorResponse message

### DIFF
--- a/pynvim/api/nvim.py
+++ b/pynvim/api/nvim.py
@@ -208,7 +208,7 @@ class Nvim(object):
             args = walk(self._from_nvim, args)
             try:
                 result = request_cb(name, args)
-            except Exception as exc:
+            except Exception:
                 self._err_cb("error caught in request handler '{} {}': {}"
                              .format(name, args, format_exc_msg()))
                 raise
@@ -219,7 +219,7 @@ class Nvim(object):
             args = walk(self._from_nvim, args)
             try:
                 notification_cb(name, args)
-            except Exception as exc:
+            except Exception:
                 self._err_cb("error caught in notification handler '{} {}': {}"
                              .format(name, args, format_exc_msg()))
                 raise
@@ -443,7 +443,7 @@ class Nvim(object):
         def handler():
             try:
                 fn(*args, **kwargs)
-            except Exception as err:
+            except Exception:
                 msg = ("error caught while executing async callback:\n"
                        "{}the call was requested at\n{}"
                        .format(format_exc_msg(), call_point))

--- a/pynvim/api/nvim.py
+++ b/pynvim/api/nvim.py
@@ -208,9 +208,9 @@ class Nvim(object):
             args = walk(self._from_nvim, args)
             try:
                 result = request_cb(name, args)
-            except Exception:
-                msg = ("error caught in request handler '{} {}'\n{}\n\n"
-                       .format(name, args, format_exc_skip(1)))
+            except Exception as exc:
+                msg = ("error caught in request handler '{} {}': {}\n{}\n\n"
+                       .format(name, args, exc, format_exc_skip(1)))
                 self._err_cb(msg)
                 raise
             return walk(self._to_nvim, result)
@@ -220,9 +220,9 @@ class Nvim(object):
             args = walk(self._from_nvim, args)
             try:
                 notification_cb(name, args)
-            except Exception:
-                msg = ("error caught in notification handler '{} {}'\n{}\n\n"
-                       .format(name, args, format_exc_skip(1)))
+            except Exception as exc:
+                msg = ("error caught in notification handler '{} {}': {}\n{}\n\n"  # noqa
+                       .format(name, args, exc, format_exc_skip(1)))
                 self._err_cb(msg)
                 raise
 

--- a/pynvim/api/nvim.py
+++ b/pynvim/api/nvim.py
@@ -13,7 +13,7 @@ from .common import (NvimError, Remote, RemoteApi, RemoteMap, RemoteSequence,
 from .tabpage import Tabpage
 from .window import Window
 from ..compat import IS_PYTHON3
-from ..util import Version, format_exc_skip
+from ..util import Version, format_exc_msg
 
 __all__ = ('Nvim')
 
@@ -209,9 +209,8 @@ class Nvim(object):
             try:
                 result = request_cb(name, args)
             except Exception as exc:
-                msg = ("error caught in request handler '{} {}': {}\n{}\n\n"
-                       .format(name, args, exc, format_exc_skip(1)))
-                self._err_cb(msg)
+                self._err_cb("error caught in request handler '{} {}': {}"
+                             .format(name, args, format_exc_msg()))
                 raise
             return walk(self._to_nvim, result)
 
@@ -221,9 +220,8 @@ class Nvim(object):
             try:
                 notification_cb(name, args)
             except Exception as exc:
-                msg = ("error caught in notification handler '{} {}': {}\n{}\n\n"  # noqa
-                       .format(name, args, exc, format_exc_skip(1)))
-                self._err_cb(msg)
+                self._err_cb("error caught in notification handler '{} {}': {}"
+                             .format(name, args, format_exc_msg()))
                 raise
 
         self._session.run(filter_request_cb, filter_notification_cb, setup_cb)
@@ -447,8 +445,8 @@ class Nvim(object):
                 fn(*args, **kwargs)
             except Exception as err:
                 msg = ("error caught while executing async callback:\n"
-                       "{!r}\n{}\n \nthe call was requested at\n{}"
-                       .format(err, format_exc_skip(1), call_point))
+                       "{}the call was requested at\n{}"
+                       .format(format_exc_msg(), call_point))
                 self._err_cb(msg)
                 raise
         self._session.threadsafe_call(handler)

--- a/pynvim/plugin/host.py
+++ b/pynvim/plugin/host.py
@@ -12,7 +12,7 @@ from . import script_host
 from ..api import decode_if_bytes, walk
 from ..compat import IS_PYTHON3, find_module
 from ..msgpack_rpc import ErrorResponse
-from ..util import format_exc_skip, get_client_info
+from ..util import format_exc_msg, get_client_info
 
 __all__ = ('Host')
 
@@ -102,13 +102,13 @@ class Host(object):
         except Exception as exc:
             if sync:
                 # NOTE: v:exception only contains the first line.
-                msg = ("error caught in request handler '{} {}': {}\n{}"
-                       .format(name, args, exc, format_exc_skip(1)))
-                raise ErrorResponse(msg)
+                raise ErrorResponse(
+                    "error caught in request handler '{} {}': {}"
+                    .format(name, args, format_exc_msg()))
             else:
-                msg = ("error caught in async handler '{} {}': {}\n{}\n"
-                       .format(name, args, exc, format_exc_skip(1)))
-                self._on_async_err(msg + "\n")
+                self._on_async_err(
+                    "error caught in async handler '{} {}': {}"
+                    .format(name, args, format_exc_msg()))
 
     def _on_request(self, name, args):
         """Handle a msgpack-rpc request."""

--- a/pynvim/plugin/host.py
+++ b/pynvim/plugin/host.py
@@ -99,10 +99,11 @@ class Host(object):
             args.insert(0, nvim_bind)
         try:
             return fn(*args)
-        except Exception:
+        except Exception as exc:
             if sync:
-                msg = ("error caught in request handler '{} {}':\n{}"
-                       .format(name, args, format_exc_skip(1)))
+                # NOTE: v:exception only contains the first line.
+                msg = ("error caught in request handler '{} {}': {}\n{}"
+                       .format(name, args, exc, format_exc_skip(1)))
                 raise ErrorResponse(msg)
             else:
                 msg = ("error caught in async handler '{} {}'\n{}\n"

--- a/pynvim/plugin/host.py
+++ b/pynvim/plugin/host.py
@@ -99,7 +99,7 @@ class Host(object):
             args.insert(0, nvim_bind)
         try:
             return fn(*args)
-        except Exception as exc:
+        except Exception:
             if sync:
                 # NOTE: v:exception only contains the first line.
                 raise ErrorResponse(

--- a/pynvim/plugin/host.py
+++ b/pynvim/plugin/host.py
@@ -106,8 +106,8 @@ class Host(object):
                        .format(name, args, exc, format_exc_skip(1)))
                 raise ErrorResponse(msg)
             else:
-                msg = ("error caught in async handler '{} {}'\n{}\n"
-                       .format(name, args, format_exc_skip(1)))
+                msg = ("error caught in async handler '{} {}': {}\n{}\n"
+                       .format(name, args, exc, format_exc_skip(1)))
                 self._on_async_err(msg + "\n")
 
     def _on_request(self, name, args):

--- a/pynvim/plugin/script_host.py
+++ b/pynvim/plugin/script_host.py
@@ -9,7 +9,7 @@ from .decorators import plugin, rpc_export
 from ..api import Nvim, walk
 from ..compat import IS_PYTHON3
 from ..msgpack_rpc import ErrorResponse
-from ..util import format_exc_skip
+from ..util import format_exc_msg
 
 __all__ = ('ScriptHost',)
 
@@ -92,7 +92,7 @@ class ScriptHost(object):
         try:
             exec(script, self.module.__dict__)
         except Exception:
-            raise ErrorResponse(format_exc_skip(1))
+            raise ErrorResponse(format_exc_msg())
 
     @rpc_export('python_execute_file', sync=True)
     def python_execute_file(self, file_path, range_start, range_stop):
@@ -103,7 +103,7 @@ class ScriptHost(object):
             try:
                 exec(script, self.module.__dict__)
             except Exception:
-                raise ErrorResponse(format_exc_skip(1))
+                raise ErrorResponse(format_exc_msg())
 
     @rpc_export('python_do_range', sync=True)
     def python_do_range(self, start, stop, code):

--- a/pynvim/util.py
+++ b/pynvim/util.py
@@ -12,6 +12,12 @@ def format_exc_skip(skip, limit=None):
     return (''.join(format_exception(etype, val, tb, limit))).rstrip()
 
 
+def format_exc_msg(skip=1, limit=None):
+    """Format ``exc`` to be used in error messages."""
+    _, exc, _ = sys.exc_info()
+    return "{!r}\n{}\n\n".format(exc, format_exc_skip(skip))
+
+
 # Taken from SimpleNamespace in python 3
 class Version:
     """Helper class for version info."""

--- a/pynvim/util.py
+++ b/pynvim/util.py
@@ -33,7 +33,7 @@ def format_exc_msg(skip=1, limit=None):
         exc_msg = repr(value)
     else:
         exc_msg = format_exception_only(etype, value)[-1].rstrip('\n')
-    return "{!s}\n{}\n\n".format(exc_msg, format_exc_skip(skip))
+    return "{!s}\n{}".format(exc_msg, format_exc_skip(skip))
 
 
 # Taken from SimpleNamespace in python 3


### PR DESCRIPTION
`v:exception` only contains the first line, and therefore the real error will not be visible in Neovim, e.g. `PermissionDenied`.
Adding it to the first line of the message helps.  This is https://github.com/neovim/python-client/commit/194317d9490962b0e69a590623d49af938f968ad.

And then I've done it in other places, too - but without testing it.
