### PR TITLE
[WIP] Use function name for decorators

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 *.egg-info/
 __pycache__
+.pytest_cache/
 neovim/ui/screen.c
 neovim/ui/screen.so
 build/

--- a/neovim/plugin/decorators.py
+++ b/neovim/plugin/decorators.py
@@ -42,11 +42,16 @@ def rpc_export(rpc_method_name, sync=False):
     return dec
 
 
-def command(name, nargs=0, complete=None, range=None, count=None, bang=False,
-            register=False, sync=False, allow_nested=False, eval=None):
+def command(name=None, nargs=0, complete=None, range=None,
+            count=None, bang=False, register=False, sync=False,
+            allow_nested=False, eval=None):
     """Tag a function or plugin method as a Nvim command handler."""
     def dec(f):
-        f._nvim_rpc_method_name = 'command:{}'.format(name)
+        if not name:
+            command_name = capitalize_name(f.__name__)
+        else:
+            command_name = name
+        f._nvim_rpc_method_name = 'command:{}'.format(command_name)
         f._nvim_rpc_sync = sync
         f._nvim_bind = True
         f._nvim_prefix_plugin_path = True
@@ -80,7 +85,7 @@ def command(name, nargs=0, complete=None, range=None, count=None, bang=False,
 
         f._nvim_rpc_spec = {
             'type': 'command',
-            'name': name,
+            'name': command_name,
             'sync': rpc_sync,
             'opts': opts
         }
@@ -88,10 +93,14 @@ def command(name, nargs=0, complete=None, range=None, count=None, bang=False,
     return dec
 
 
-def autocmd(name, pattern='*', sync=False, allow_nested=False, eval=None):
+def autocmd(name=None, pattern='*', sync=False, allow_nested=False, eval=None):
     """Tag a function or plugin method as a Nvim autocommand handler."""
     def dec(f):
-        f._nvim_rpc_method_name = 'autocmd:{}:{}'.format(name, pattern)
+        if not name:
+            autocmd_name = capitalize_name(f.__name__)
+        else:
+            autocmd_name = name
+        f._nvim_rpc_method_name = 'autocmd:{}:{}'.format(autocmd_name, pattern)
         f._nvim_rpc_sync = sync
         f._nvim_bind = True
         f._nvim_prefix_plugin_path = True
@@ -110,7 +119,7 @@ def autocmd(name, pattern='*', sync=False, allow_nested=False, eval=None):
 
         f._nvim_rpc_spec = {
             'type': 'autocmd',
-            'name': name,
+            'name': autocmd_name,
             'sync': rpc_sync,
             'opts': opts
         }
@@ -118,10 +127,15 @@ def autocmd(name, pattern='*', sync=False, allow_nested=False, eval=None):
     return dec
 
 
-def function(name, range=False, sync=False, allow_nested=False, eval=None):
+def function(name=None, range=False, sync=False,
+             allow_nested=False, eval=None):
     """Tag a function or plugin method as a Nvim function handler."""
     def dec(f):
-        f._nvim_rpc_method_name = 'function:{}'.format(name)
+        if not name:
+            function_name = capitalize_name(f.__name__)
+        else:
+            function_name = name
+        f._nvim_rpc_method_name = 'function:{}'.format(function_name)
         f._nvim_rpc_sync = sync
         f._nvim_bind = True
         f._nvim_prefix_plugin_path = True
@@ -141,12 +155,21 @@ def function(name, range=False, sync=False, allow_nested=False, eval=None):
 
         f._nvim_rpc_spec = {
             'type': 'function',
-            'name': name,
+            'name': function_name,
             'sync': rpc_sync,
             'opts': opts
         }
         return f
     return dec
+
+
+def capitalize_name(name):
+    words = [
+        word[0].upper() + word[1:]
+        for word in name.split('_')
+        if word
+    ]
+    return ''.join(words)
 
 
 def shutdown_hook(f):

--- a/test/test_decorators.py
+++ b/test/test_decorators.py
@@ -1,4 +1,4 @@
-from neovim.plugin.decorators import command
+from neovim.plugin.decorators import autocmd, command, function
 
 
 def test_command_count():
@@ -26,3 +26,81 @@ def test_command_count():
     decorated = command('test', count=count_value)(function)
     assert 'count' in decorated._nvim_rpc_spec['opts']
     assert decorated._nvim_rpc_spec['opts']['count'] == count_value
+
+
+def test_name_command():
+    def newcommand():
+        return
+
+    def newCommand():
+        return
+
+    def new_command():
+        return
+
+    def _new_command():
+        return
+
+    decorated = command()(newcommand)
+    assert decorated._nvim_rpc_spec['name'] == 'Newcommand'
+
+    decorated = command()(newCommand)
+    assert decorated._nvim_rpc_spec['name'] == 'NewCommand'
+
+    decorated = command()(new_command)
+    assert decorated._nvim_rpc_spec['name'] == 'NewCommand'
+
+    decorated = command()(_new_command)
+    assert decorated._nvim_rpc_spec['name'] == 'NewCommand'
+
+
+def test_name_function():
+    def newfunction():
+        return
+
+    def newFunction():
+        return
+
+    def new_function():
+        return
+
+    def _new_function():
+        return
+
+    decorated = function()(newfunction)
+    assert decorated._nvim_rpc_spec['name'] == 'Newfunction'
+
+    decorated = function()(newFunction)
+    assert decorated._nvim_rpc_spec['name'] == 'NewFunction'
+
+    decorated = function()(new_function)
+    assert decorated._nvim_rpc_spec['name'] == 'NewFunction'
+
+    decorated = function()(_new_function)
+    assert decorated._nvim_rpc_spec['name'] == 'NewFunction'
+
+
+def test_name_autocmd():
+    def newautocmd():
+        return
+
+    def newAutocmd():
+        return
+
+    def new_autocmd():
+        return
+
+    def _new_autocmd():
+        return
+
+    decorated = autocmd()(newautocmd)
+    assert decorated._nvim_rpc_spec['name'] == 'Newautocmd'
+
+    decorated = autocmd()(newAutocmd)
+    assert decorated._nvim_rpc_spec['name'] == 'NewAutocmd'
+
+    decorated = autocmd()(new_autocmd)
+    assert decorated._nvim_rpc_spec['name'] == 'NewAutocmd'
+
+    decorated = autocmd()(_new_autocmd)
+    assert decorated._nvim_rpc_spec['name'] == 'NewAutocmd'

--- a/tox.ini
+++ b/tox.ini
@@ -8,7 +8,7 @@ deps=
   pytest
   pytest-xdist
   pyuv: pyuv
-commands=python -m pytest -s
+commands=python -m pytest -s {posargs}
 
 [testenv:checkqa]
 deps =


### PR DESCRIPTION
Sometimes is kind of redundant to write the function/command/autocmd name on each decorator. Also, this can help with cases like #334.

Please, let me know if you want this feature so, I can continue :), thanks

What is missing?

- [ ] Update docs