### PR TITLE
lint: Enforce "line break before operator"

### DIFF
--- a/pynvim/api/common.py
+++ b/pynvim/api/common.py
@@ -39,8 +39,8 @@ class Remote(object):
 
     def __eq__(self, other):
         """Return True if `self` and `other` are the same object."""
-        return (hasattr(other, 'code_data') and
-                other.code_data == self.code_data)
+        return (hasattr(other, 'code_data')
+                and other.code_data == self.code_data)
 
     def __hash__(self):
         """Return hash based on remote object id."""

--- a/pynvim/api/nvim.py
+++ b/pynvim/api/nvim.py
@@ -166,8 +166,8 @@ class Nvim(object):
         present and True, a asynchronous notification is sent instead. This
         will never block, and the return value or error is ignored.
         """
-        if (self._session._loop_thread is not None and
-                threading.current_thread() != self._session._loop_thread):
+        if (self._session._loop_thread is not None
+                and threading.current_thread() != self._session._loop_thread):
 
             msg = ("Request from non-main thread.\n"
                    "Requests from different threads should be wrapped "
@@ -403,8 +403,8 @@ class Nvim(object):
         return self.request('nvim_err_write', msg, **kwargs)
 
     def _thread_invalid(self):
-        return (self._session._loop_thread is not None and
-                threading.current_thread() != self._session._loop_thread)
+        return (self._session._loop_thread is not None
+                and threading.current_thread() != self._session._loop_thread)
 
     def quit(self, quit_command='qa!'):
         """Send a quit command to Nvim.

--- a/pynvim/msgpack_rpc/session.py
+++ b/pynvim/msgpack_rpc/session.py
@@ -193,8 +193,8 @@ class Session(object):
         def handler():
             try:
                 rv = self._request_cb(name, args)
-                debug('greenlet %s finished executing, ' +
-                      'sending %s as response', gr, rv)
+                debug('greenlet %s finished executing, '
+                      + 'sending %s as response', gr, rv)
                 response.send(rv)
             except ErrorResponse as err:
                 warn("error response from request '%s %s': %s", name,

--- a/pynvim/plugin/host.py
+++ b/pynvim/plugin/host.py
@@ -202,13 +202,13 @@ class Host(object):
             # register in the rpc handler dict
             if sync:
                 if method in self._request_handlers:
-                    raise Exception(('Request handler for "{}" is ' +
-                                    'already registered').format(method))
+                    raise Exception(('Request handler for "{}" is '
+                                    + 'already registered').format(method))
                 self._request_handlers[method] = fn_wrapped
             else:
                 if method in self._notification_handlers:
-                    raise Exception(('Notification handler for "{}" is ' +
-                                    'already registered').format(method))
+                    raise Exception(('Notification handler for "{}" is '
+                                    + 'already registered').format(method))
                 self._notification_handlers[method] = fn_wrapped
             if hasattr(fn, '_nvim_rpc_spec'):
                 specs.append(fn._nvim_rpc_spec)

--- a/pynvim/plugin/script_host.py
+++ b/pynvim/plugin/script_host.py
@@ -143,8 +143,8 @@ class ScriptHost(object):
                 elif isinstance(result, basestring):
                     newlines.append(result)
                 else:
-                    exception = TypeError('pydo should return a string ' +
-                                          'or None, found %s instead'
+                    exception = TypeError('pydo should return a string '
+                                          + 'or None, found %s instead'
                                           % result.__class__.__name__)
                     break
                 linenr += 1

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [flake8]
-ignore = D211,E731,D401,W504
+ignore = D211,E731,D401,W503
 
 [tool:pytest]
 testpaths = test


### PR DESCRIPTION
Converse of #361: Ignore W503 and enforce W504.
This matches the style of Nvim core and is just better :)