### PR TITLE
Revert: fix "imp" module deprecation warnings

### DIFF
--- a/pynvim/compat.py
+++ b/pynvim/compat.py
@@ -2,32 +2,18 @@
 
 import sys
 import warnings
-if sys.version_info >= (3, 7):
-    import types
-    import importlib
-else:
-    import imp  # Deprecated in Python 3.7+
-if sys.version_info >= (3, 4):
-    from importlib.machinery import PathFinder
-    original_find_module = PathFinder.find_spec
-else:
-    from imp import find_module as original_find_module
+from imp import find_module as original_find_module
 
 
 IS_PYTHON3 = sys.version_info >= (3, 0)
 
-if sys.version_info >= (3, 7):
-    load_module = importlib.import_module
-    new_module = types.ModuleType
-else:
-    load_module = imp.load_module
-    new_module = imp.new_module
 
 if IS_PYTHON3:
     def find_module(fullname, path):
-        """Compat wrapper for imp.find_module, or find_spec in Python 3.7+.
+        """Compatibility wrapper for imp.find_module.
 
-        Automatically decodes arguments (must be Unicode in Python3).
+        Automatically decodes arguments of find_module, in Python3
+        they must be Unicode
         """
         if isinstance(fullname, bytes):
             fullname = fullname.decode()

--- a/pynvim/plugin/script_host.py
+++ b/pynvim/plugin/script_host.py
@@ -1,4 +1,5 @@
 """Legacy python/python3-vim emulation."""
+import imp
 import io
 import logging
 import os
@@ -6,7 +7,7 @@ import sys
 
 from .decorators import plugin, rpc_export
 from ..api import Nvim, walk
-from ..compat import IS_PYTHON3, find_module, load_module, new_module
+from ..compat import IS_PYTHON3
 from ..msgpack_rpc import ErrorResponse
 from ..util import format_exc_skip
 
@@ -36,7 +37,7 @@ class ScriptHost(object):
         """Initialize the legacy python-vim environment."""
         self.setup(nvim)
         # context where all code will run
-        self.module = new_module('__main__')
+        self.module = imp.new_module('__main__')
         nvim.script_context = self.module
         # it seems some plugins assume 'sys' is already imported, so do it now
         exec('import sys', self.module.__dict__)
@@ -215,11 +216,11 @@ def path_hook(nvim):
         if idx > 0:
             name = oldtail[:idx]
             tail = oldtail[idx + 1:]
-            fmr = find_module(name, path)
-            module = find_module(fullname[:-len(oldtail)] + name, *fmr)
+            fmr = imp.find_module(name, path)
+            module = imp.find_module(fullname[:-len(oldtail)] + name, *fmr)
             return _find_module(fullname, tail, module.__path__)
         else:
-            return find_module(fullname, path)
+            return imp.find_module(fullname, path)
 
     class VimModuleLoader(object):
         def __init__(self, module):
@@ -231,7 +232,7 @@ def path_hook(nvim):
                 return sys.modules[fullname]
             except KeyError:
                 pass
-            return load_module(fullname, *self.module)
+            return imp.load_module(fullname, *self.module)
 
     class VimPathFinder(object):
         @staticmethod


### PR DESCRIPTION
closes #368
regresses #351

There is more involved with migrating to `find_spec()` and Python's new
enterprise-quality API.  We may not be able to fashion a compat wrapper
that mimics the old find_module() API.

- `find_spec()` returns `importlib.machinery.ModuleSpec` object, unlike
  `find_module()` which returns 3 values.
- `host.py` sends the result to `imp.load_module()` ...

Reverts the following:
8df286143cce
a29f34e98e2b
e29e4dfee094