### PR TITLE
util: don't add extra newlines in format_exc_skip

### DIFF
--- a/pynvim/util.py
+++ b/pynvim/util.py
@@ -6,10 +6,10 @@ from traceback import format_exception
 
 def format_exc_skip(skip, limit=None):
     """Like traceback.format_exc but allow skipping the first frames."""
-    type, val, tb = sys.exc_info()
+    etype, val, tb = sys.exc_info()
     for i in range(skip):
         tb = tb.tb_next
-    return ('\n'.join(format_exception(type, val, tb, limit))).rstrip()
+    return (''.join(format_exception(etype, val, tb, limit))).rstrip()
 
 
 # Taken from SimpleNamespace in python 3


### PR DESCRIPTION
Each item will already end in an newline. This will make a difference when we start to use multiline exceptions in Nvim core (https://github.com/neovim/neovim/pull/7969)