### PR TITLE
Fixing issue #398: `buf1 != buf2` doesn't work in python2

### DIFF
--- a/pynvim/api/buffer.py
+++ b/pynvim/api/buffer.py
@@ -83,6 +83,12 @@ class Buffer(Remote):
         """
         self.__setitem__(idx, None)
 
+    def __ne__(self, other):
+        """ Test inequality of Buffers.
+
+        Necessary for Python 2 compatibility """
+        return not self.__eq__(other)
+
     def append(self, lines, index=-1):
         """Append a string or list of lines to the buffer."""
         if isinstance(lines, (basestring, bytes)):

--- a/test/test_buffer.py
+++ b/test/test_buffer.py
@@ -93,7 +93,7 @@ def test_options(vim):
     vim.current.buffer.options['define'] = 'test'
     assert vim.current.buffer.options['define'] == 'test'
     # Doesn't change the global value
-    assert vim.options['define'] == '^\s*#\s*define'
+    assert vim.options['define'] == r'^\s*#\s*define'
 
 
 def test_number(vim):

--- a/test/test_buffer.py
+++ b/test/test_buffer.py
@@ -172,3 +172,9 @@ def test_update_highlights(vim):
     vim.current.buffer[:] = ['a', 'b', 'c']
     src_id = vim.new_highlight_source()
     vim.current.buffer.update_highlights(src_id, [["Comment", 0, 0, -1], ("String", 1, 0, 1)], clear=True, async_=False)
+
+
+def test_buffer_inequality(vim):
+    b = vim.current.buffer
+    assert not (b != vim.current.buffer)
+


### PR DESCRIPTION
Adding __ne__ function to pynvim.api.buffer.Buffer to correctly test
two buffers are not equal in Python 2. Test added to demonstrate.

Also fixing warning message in test_buffer:96