### PR TITLE
tox: use extras=test

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -4,9 +4,8 @@ envlist =
   py36-docs
 
 [testenv]
+extras = test
 deps =
-  pytest
-  pytest-xdist
   pytest-timeout
   pyuv: pyuv
 passenv = PYTEST_ADDOPTS


### PR DESCRIPTION
This uses `extras_require` from `setup.py` (a central place to define
requirements for testing).

Removes "pytest-xdist", which is not used currently (and not necessary
given that tests are fast).