### PR TITLE
 Raise KeyError for missing keys

### DIFF
--- a/pynvim/api/common.py
+++ b/pynvim/api/common.py
@@ -85,7 +85,10 @@ class RemoteMap(object):
 
     def __getitem__(self, key):
         """Return a map value by key."""
-        return self._get(key)
+        try:
+            return self._get(key)
+        except Exception:
+            raise KeyError
 
     def __setitem__(self, key, value):
         """Set a map value by key(if the setter was provided)."""

--- a/pynvim/api/common.py
+++ b/pynvim/api/common.py
@@ -88,7 +88,7 @@ class RemoteMap(object):
         try:
             return self._get(key)
         except Exception:
-            raise KeyError
+            raise NvimAPIKeyError
 
     def __setitem__(self, key, value):
         """Set a map value by key(if the setter was provided)."""
@@ -181,3 +181,7 @@ def walk(fn, obj, *args, **kwargs):
         return dict((walk(fn, k, *args), walk(fn, v, *args)) for k, v in
                     obj.items())
     return fn(obj, *args, **kwargs)
+
+
+class NvimAPIKeyError(KeyError):
+    pass

--- a/test/test_buffer.py
+++ b/test/test_buffer.py
@@ -2,6 +2,7 @@ import os
 import pytest
 
 from pynvim.compat import IS_PYTHON3
+from pynvim.api.common import NvimAPIKeyError
 
 
 def test_repr(vim):
@@ -155,7 +156,7 @@ def test_invalid_utf8(vim):
 
 
 def test_get_exceptions(vim):
-    with pytest.raises(KeyError):
+    with pytest.raises(NvimAPIKeyError):
         vim.current.buffer.options['invalid-option']
 
 

--- a/test/test_buffer.py
+++ b/test/test_buffer.py
@@ -1,4 +1,5 @@
 import os
+import pytest
 
 from pynvim.compat import IS_PYTHON3
 
@@ -154,11 +155,8 @@ def test_invalid_utf8(vim):
 
 
 def test_get_exceptions(vim):
-    try:
+    with pytest.raises(KeyError):
         vim.current.buffer.options['invalid-option']
-        assert False
-    except vim.error:
-        pass
 
 
 def test_set_items_for_range(vim):

--- a/test/test_vim.py
+++ b/test/test_vim.py
@@ -194,7 +194,6 @@ def test_key_error(vim):
     with pytest.raises(KeyError):
         vim.current.buffer.vars['doesnotexist']
 
-
 lua_code = """
 local a = vim.api
 local y = ...

--- a/test/test_vim.py
+++ b/test/test_vim.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 import os
+import pytest
 import sys
 import tempfile
 
@@ -187,6 +188,11 @@ def test_cwd(vim, tmpdir):
     cwd_python = vim.command_output('{} print(os.getcwd())'.format(pycmd))
     assert cwd_python == cwd_vim
     assert cwd_python != cwd_before
+
+
+def test_key_error(vim):
+    with pytest.raises(KeyError):
+        vim.current.buffer.vars['doesnotexist']
 
 
 lua_code = """


### PR DESCRIPTION
Fixing issue neovim#402
"Raise KeyError for missing options / vars".