### PR TITLE
tests: remove cleanup_func

### DIFF
--- a/test/conftest.py
+++ b/test/conftest.py
@@ -1,6 +1,5 @@
 import json
 import os
-import textwrap
 
 import pytest
 

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -9,50 +9,6 @@ import pynvim
 pynvim.setup_logging("test")
 
 
-@pytest.fixture(autouse=True)
-def cleanup_func(vim):
-    fun = textwrap.dedent('''function! BeforeEachTest()
-        set all&
-        redir => groups
-        silent augroup
-        redir END
-        for group in split(groups)
-            exe 'augroup '.group
-            autocmd!
-            augroup END
-        endfor
-        autocmd!
-        tabnew
-        let curbufnum = eval(bufnr('%'))
-        redir => buflist
-        silent ls!
-        redir END
-        let bufnums = []
-        for buf in split(buflist, '\\n')
-            let bufnum = eval(split(buf, '[ u]')[0])
-            if bufnum != curbufnum
-            call add(bufnums, bufnum)
-            endif
-        endfor
-        if len(bufnums) > 0
-            exe 'silent bwipeout! '.join(bufnums, ' ')
-        endif
-        silent tabonly
-        for k in keys(g:)
-            exe 'unlet g:'.k
-        endfor
-        filetype plugin indent off
-        mapclear
-        mapclear!
-        abclear
-        comclear
-        endfunction
-    ''')
-    vim.command(fun)
-    vim.command('call BeforeEachTest()')
-    assert len(vim.tabpages) == len(vim.windows) == len(vim.buffers) == 1
-
-
 @pytest.fixture
 def vim():
     child_argv = os.environ.get('NVIM_CHILD_ARGV')

--- a/test/test_buffer.py
+++ b/test/test_buffer.py
@@ -7,7 +7,7 @@ from pynvim.compat import IS_PYTHON3
 
 
 def test_repr(vim):
-    assert repr(vim.current.buffer) == "<Buffer(handle=2)>"
+    assert repr(vim.current.buffer) == "<Buffer(handle=1)>"
 
 
 def test_get_length(vim):

--- a/test/test_tabpage.py
+++ b/test/test_tabpage.py
@@ -45,4 +45,4 @@ def test_number(vim):
 
 
 def test_repr(vim):
-    assert repr(vim.current.tabpage) == "<Tabpage(handle=2)>"
+    assert repr(vim.current.tabpage) == "<Tabpage(handle=1)>"

--- a/test/test_vim.py
+++ b/test/test_vim.py
@@ -45,7 +45,9 @@ def test_command_error(vim):
 def test_eval(vim):
     vim.command('let g:v1 = "a"')
     vim.command('let g:v2 = [1, 2, {"v3": 3}]')
-    assert vim.eval('g:') == {'v1': 'a', 'v2': [1, 2, {'v3': 3}]}
+    g = vim.eval('g:')
+    assert g['v1'] == 'a'
+    assert g['v2'] == [1, 2, {'v3': 3}]
 
 
 def test_call(vim):

--- a/test/test_window.py
+++ b/test/test_window.py
@@ -121,4 +121,4 @@ def test_handle(vim):
 
 
 def test_repr(vim):
-    assert repr(vim.current.window) == "<Window(handle=1001)>"
+    assert repr(vim.current.window) == "<Window(handle=1000)>"


### PR DESCRIPTION
The "vim" fixture uses a new session always.

It was added when migrating to pytest in b65f62d, but is not really
necessary.  It could still be used to e.g. ensure tests are cleaning up
after themselves, but this is also not necessary really.

Adjusts existing tests, mainly with regard to handle IDs.