### PR TITLE
Make pytest-runner conditional

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -8,8 +8,11 @@ install_requires = [
     'msgpack>=0.5.0',
 ]
 
+needs_pytest = {'pytest', 'test', 'ptr'}.intersection(sys.argv)
+pytest_runner = ['pytest-runner'] if needs_pytest else []
+
 setup_requires = [
-    'pytest-runner'
+    pytest_runner,
 ]
 
 tests_require = [

--- a/setup.py
+++ b/setup.py
@@ -12,8 +12,7 @@ needs_pytest = {'pytest', 'test', 'ptr'}.intersection(sys.argv)
 pytest_runner = ['pytest-runner'] if needs_pytest else []
 
 setup_requires = [
-    pytest_runner,
-]
+] + pytest_runner,
 
 tests_require = [
     'pytest>=3.4.0',


### PR DESCRIPTION
pytest runner should not be unconditionally included in setup_requires

This change makes it conditional on setup.py invocation arguments as recommended upstream [1]

See: https://github.com/pytest-dev/pytest/issues/3814

Identified via: [FreeBSD Ports Bug 242065](https://bugs.freebsd.org/bugzilla/show_bug.cgi?id=242065)

Closes #417
Closes #420

[1] https://pytest-runner.readthedocs.io/en/latest/#conditional-requirement