### PR TITLE
asyncio: pipe_data_received: call _on_error

### DIFF
--- a/pynvim/msgpack_rpc/event_loop/asyncio.py
+++ b/pynvim/msgpack_rpc/event_loop/asyncio.py
@@ -68,7 +68,7 @@ class AsyncioEventLoop(BaseEventLoop, asyncio.Protocol,
     def pipe_data_received(self, fd, data):
         """Used to signal `asyncio.SubprocessProtocol` of incoming data."""
         if fd == 2:  # stderr fd number
-            self._on_stderr(data)
+            self._on_error(data)
         elif self._on_data:
             self._on_data(data)
         else:


### PR DESCRIPTION
`_on_stderr` does not exist.

(found by mypy)

I might be missing something here, and it does not appear to be covered with tests.