### PR TITLE
Close #450: Modify all imports in the repository to absolute imports

### DIFF
--- a/pynvim/__init__.py
+++ b/pynvim/__init__.py
@@ -6,13 +6,13 @@ import logging
 import os
 import sys
 
-from .api import Nvim, NvimError
-from .compat import IS_PYTHON3
-from .msgpack_rpc import (ErrorResponse, child_session, socket_session,
-                          stdio_session, tcp_session)
-from .plugin import (Host, autocmd, command, decode, encoding, function,
-                     plugin, rpc_export, shutdown_hook)
-from .util import VERSION, Version
+from pynvim.api import Nvim, NvimError
+from pynvim.compat import IS_PYTHON3
+from pynvim.msgpack_rpc import (ErrorResponse, child_session, socket_session,
+                                stdio_session, tcp_session)
+from pynvim.plugin import (Host, autocmd, command, decode, encoding, function,
+                           plugin, rpc_export, shutdown_hook)
+from pynvim.util import VERSION, Version
 
 
 __all__ = ('tcp_session', 'socket_session', 'stdio_session', 'child_session',

--- a/pynvim/api/__init__.py
+++ b/pynvim/api/__init__.py
@@ -4,11 +4,11 @@ This package implements a higher-level API that wraps msgpack-rpc `Session`
 instances.
 """
 
-from .buffer import Buffer
-from .common import decode_if_bytes, walk
-from .nvim import Nvim, NvimError
-from .tabpage import Tabpage
-from .window import Window
+from pynvim.api.buffer import Buffer
+from pynvim.api.common import decode_if_bytes, walk
+from pynvim.api.nvim import Nvim, NvimError
+from pynvim.api.tabpage import Tabpage
+from pynvim.api.window import Window
 
 
 __all__ = ('Nvim', 'Buffer', 'Window', 'Tabpage', 'NvimError',

--- a/pynvim/api/buffer.py
+++ b/pynvim/api/buffer.py
@@ -1,6 +1,6 @@
 """API for working with a Nvim Buffer."""
-from .common import Remote
-from ..compat import IS_PYTHON3, check_async
+from pynvim.api.common import Remote
+from pynvim.compat import IS_PYTHON3, check_async
 
 
 __all__ = ('Buffer')

--- a/pynvim/api/common.py
+++ b/pynvim/api/common.py
@@ -3,7 +3,7 @@ import functools
 
 from msgpack import unpackb
 
-from ..compat import unicode_errors_default
+from pynvim.compat import unicode_errors_default
 
 __all__ = ()
 

--- a/pynvim/api/nvim.py
+++ b/pynvim/api/nvim.py
@@ -7,13 +7,13 @@ from traceback import format_stack
 
 from msgpack import ExtType
 
-from .buffer import Buffer
-from .common import (NvimError, Remote, RemoteApi, RemoteMap, RemoteSequence,
+from pynvim.api.buffer import Buffer
+from pynvim.api.common import (NvimError, Remote, RemoteApi, RemoteMap, RemoteSequence,
                      decode_if_bytes, walk)
-from .tabpage import Tabpage
-from .window import Window
-from ..compat import IS_PYTHON3
-from ..util import Version, format_exc_skip
+from pynvim.api.tabpage import Tabpage
+from pynvim.api.window import Window
+from pynvim.compat import IS_PYTHON3
+from pynvim.util import Version, format_exc_skip
 
 __all__ = ('Nvim')
 

--- a/pynvim/api/nvim.py
+++ b/pynvim/api/nvim.py
@@ -9,7 +9,7 @@ from msgpack import ExtType
 
 from pynvim.api.buffer import Buffer
 from pynvim.api.common import (NvimError, Remote, RemoteApi, RemoteMap, RemoteSequence,
-                     decode_if_bytes, walk)
+                               decode_if_bytes, walk)
 from pynvim.api.tabpage import Tabpage
 from pynvim.api.window import Window
 from pynvim.compat import IS_PYTHON3

--- a/pynvim/api/tabpage.py
+++ b/pynvim/api/tabpage.py
@@ -1,5 +1,5 @@
 """API for working with Nvim tabpages."""
-from .common import Remote, RemoteSequence
+from pynvim.api.common import Remote, RemoteSequence
 
 
 __all__ = ('Tabpage')

--- a/pynvim/api/window.py
+++ b/pynvim/api/window.py
@@ -1,5 +1,5 @@
 """API for working with Nvim windows."""
-from .common import Remote
+from pynvim.api.common import Remote
 
 
 __all__ = ('Window')

--- a/pynvim/msgpack_rpc/__init__.py
+++ b/pynvim/msgpack_rpc/__init__.py
@@ -4,11 +4,11 @@ This package implements a msgpack-rpc client. While it was designed for
 handling some Nvim particularities(server->client requests for example), the
 code here should work with other msgpack-rpc servers.
 """
-from .async_session import AsyncSession
-from .event_loop import EventLoop
-from .msgpack_stream import MsgpackStream
-from .session import ErrorResponse, Session
-from ..util import get_client_info
+from pynvim.msgpack_rpc.async_session import AsyncSession
+from pynvim.msgpack_rpc.event_loop import EventLoop
+from pynvim.msgpack_rpc.msgpack_stream import MsgpackStream
+from pynvim.msgpack_rpc.session import ErrorResponse, Session
+from pynvim.util import get_client_info
 
 
 __all__ = ('tcp_session', 'socket_session', 'stdio_session', 'child_session',

--- a/pynvim/msgpack_rpc/event_loop/__init__.py
+++ b/pynvim/msgpack_rpc/event_loop/__init__.py
@@ -3,21 +3,21 @@
 Tries to use pyuv as a backend, falling back to the asyncio implementation.
 """
 
-from ...compat import IS_PYTHON3
+from pynvim.compat import IS_PYTHON3
 
 # on python3 we only support asyncio, as we expose it to plugins
 if IS_PYTHON3:
-    from .asyncio import AsyncioEventLoop
+    from pynvim.msgpack_rpc.event_loop.asyncio import AsyncioEventLoop
     EventLoop = AsyncioEventLoop
 else:
     try:
         # libuv is fully implemented in C, use it when available
-        from .uv import UvEventLoop
+        from pynvim.msgpack_rpc.event_loop.uv import UvEventLoop
         EventLoop = UvEventLoop
     except ImportError:
         # asyncio(trollius on python 2) is pure python and should be more
         # portable across python implementations
-        from .asyncio import AsyncioEventLoop
+        from pynvim.msgpack_rpc.event_loop.asyncio import AsyncioEventLoop
         EventLoop = AsyncioEventLoop
 
 

--- a/pynvim/msgpack_rpc/event_loop/asyncio.py
+++ b/pynvim/msgpack_rpc/event_loop/asyncio.py
@@ -22,7 +22,7 @@ except (ImportError, SyntaxError):
     # Fallback to trollius
     import trollius as asyncio
 
-from .base import BaseEventLoop
+from pynvim.msgpack_rpc.event_loop.base import BaseEventLoop
 
 logger = logging.getLogger(__name__)
 debug, info, warn = (logger.debug, logger.info, logger.warning,)

--- a/pynvim/msgpack_rpc/event_loop/uv.py
+++ b/pynvim/msgpack_rpc/event_loop/uv.py
@@ -4,7 +4,7 @@ from collections import deque
 
 import pyuv
 
-from .base import BaseEventLoop
+from pynvim.msgpack_rpc.event_loop.base import BaseEventLoop
 
 
 class UvEventLoop(BaseEventLoop):

--- a/pynvim/msgpack_rpc/msgpack_stream.py
+++ b/pynvim/msgpack_rpc/msgpack_stream.py
@@ -3,7 +3,7 @@ import logging
 
 from msgpack import Packer, Unpacker
 
-from ..compat import unicode_errors_default
+from pynvim.compat import unicode_errors_default
 
 logger = logging.getLogger(__name__)
 debug, info, warn = (logger.debug, logger.info, logger.warning,)

--- a/pynvim/msgpack_rpc/session.py
+++ b/pynvim/msgpack_rpc/session.py
@@ -6,7 +6,7 @@ from traceback import format_exc
 
 import greenlet
 
-from ..compat import check_async
+from pynvim.compat import check_async
 
 logger = logging.getLogger(__name__)
 error, debug, info, warn = (logger.error, logger.debug, logger.info,

--- a/pynvim/plugin/__init__.py
+++ b/pynvim/plugin/__init__.py
@@ -1,8 +1,8 @@
 """Nvim plugin/host subpackage."""
 
-from .decorators import (autocmd, command, decode, encoding, function,
-                         plugin, rpc_export, shutdown_hook)
-from .host import Host
+from pynvim.plugin.decorators import (autocmd, command, decode, encoding, function,
+                                      plugin, rpc_export, shutdown_hook)
+from pynvim.plugin.host import Host
 
 
 __all__ = ('Host', 'plugin', 'rpc_export', 'command', 'autocmd',

--- a/pynvim/plugin/decorators.py
+++ b/pynvim/plugin/decorators.py
@@ -3,7 +3,7 @@
 import inspect
 import logging
 
-from ..compat import IS_PYTHON3, unicode_errors_default
+from pynvim.compat import IS_PYTHON3, unicode_errors_default
 
 logger = logging.getLogger(__name__)
 debug, info, warn = (logger.debug, logger.info, logger.warning,)

--- a/pynvim/plugin/host.py
+++ b/pynvim/plugin/host.py
@@ -8,10 +8,10 @@ import re
 from functools import partial
 from traceback import format_exc
 
-from pynvim.plugin import script_host
 from pynvim.api import decode_if_bytes, walk
 from pynvim.compat import IS_PYTHON3, find_module
 from pynvim.msgpack_rpc import ErrorResponse
+from pynvim.plugin import script_host
 from pynvim.util import format_exc_skip, get_client_info
 
 __all__ = ('Host')

--- a/pynvim/plugin/host.py
+++ b/pynvim/plugin/host.py
@@ -8,11 +8,11 @@ import re
 from functools import partial
 from traceback import format_exc
 
-from . import script_host
-from ..api import decode_if_bytes, walk
-from ..compat import IS_PYTHON3, find_module
-from ..msgpack_rpc import ErrorResponse
-from ..util import format_exc_skip, get_client_info
+from pynvim.plugin import script_host
+from pynvim.api import decode_if_bytes, walk
+from pynvim.compat import IS_PYTHON3, find_module
+from pynvim.msgpack_rpc import ErrorResponse
+from pynvim.util import format_exc_skip, get_client_info
 
 __all__ = ('Host')
 

--- a/pynvim/plugin/script_host.py
+++ b/pynvim/plugin/script_host.py
@@ -5,11 +5,11 @@ import logging
 import os
 import sys
 
-from .decorators import plugin, rpc_export
-from ..api import Nvim, walk
-from ..compat import IS_PYTHON3
-from ..msgpack_rpc import ErrorResponse
-from ..util import format_exc_skip
+from pynvim.plugin.decorators import plugin, rpc_export
+from pynvim.api import Nvim, walk
+from pynvim.compat import IS_PYTHON3
+from pynvim.msgpack_rpc import ErrorResponse
+from pynvim.util import format_exc_skip
 
 __all__ = ('ScriptHost',)
 

--- a/pynvim/plugin/script_host.py
+++ b/pynvim/plugin/script_host.py
@@ -5,10 +5,10 @@ import logging
 import os
 import sys
 
-from pynvim.plugin.decorators import plugin, rpc_export
 from pynvim.api import Nvim, walk
 from pynvim.compat import IS_PYTHON3
 from pynvim.msgpack_rpc import ErrorResponse
+from pynvim.plugin.decorators import plugin, rpc_export
 from pynvim.util import format_exc_skip
 
 __all__ = ('ScriptHost',)


### PR DESCRIPTION
@Shougo I realized that going ahead and changing all the imports wouldn't be very time intensive so I did.

In addition, I have verified that tests still pass with pytest in a venv.

However, I would like to note that:

`python -m doctest pynvim/msgpack_rpc/event_loop/base.py`

currently fails. There's a circular import issue, and even if that was resolved, it seems that Tracebacks were copy-pasted into `BaseEventLoop.__init__()`.

However that may be an issue for a different PR, and the imports mentioned in #450 are fixed