### PR TITLE
Doc updates: Indentation and underline length

### DIFF
--- a/docs/usage/python-plugin-api.rst
+++ b/docs/usage/python-plugin-api.rst
@@ -7,7 +7,7 @@ The API extensions are accessible no matter if the traditional ``:python`` inter
 as discussed on :doc:`remote-plugins`.
 
 Nvim API methods: ``vim.api``
------------
+-----------------------------
 
 Exposes Neovim API methods.
 For instance to call ``nvim_strwidth``:
@@ -38,7 +38,7 @@ same way, but python will not wait for it to finish, so the return value is
 unavailable.
 
 Vimscript functions: ``vim.funcs``
--------------
+----------------------------------
 
 Exposes vimscript functions (both builtin and global user defined functions) as a python namespace.
 For instance to set the value of a register:
@@ -51,7 +51,7 @@ These functions can also take the ``async_=True`` keyword argument, just like AP
 methods.
 
 Lua integration
------------
+---------------
 
 Python plugins can define and invoke lua code in Nvim's in-process lua
 interpreter. This is especially useful in asynchronous contexts, where an async

--- a/docs/usage/remote-plugins.rst
+++ b/docs/usage/remote-plugins.rst
@@ -75,23 +75,26 @@ find your plugin. You can now invoke Neovim:
 
 Then run ``:UpdateRemotePlugins`` and your plugin should be activated.
 
-In case you run into some issues, you can list loaded plugins:
+In case you run into some issues, you can list your loaded plugins from inside
+Neovim by running ``:scriptnames`` like so.:
 
-.. code-block:: console
+.. code-block:: vim
 
     :scriptnames
-      1: ~/path/to/your/plugin-git-repo/vimrc
-      2: /usr/share/nvim/runtime/filetype.vim
-      ...
-     25: /usr/share/nvim/runtime/plugin/zipPlugin.vim
-     26: ~/path/to/your/plugin-git-repo/plugin/lucid.vim
+    1: ~/path/to/your/plugin-git-repo/vimrc
+    2: /usr/share/nvim/runtime/filetype.vim
+    ...
+    25: /usr/share/nvim/runtime/plugin/zipPlugin.vim
+    26: ~/path/to/your/plugin-git-repo/plugin/lucid.vim
 
-You can also inspect the ``runtimepath`` like this:
+You can also inspect the ``&runtimepath`` like this:
 
-.. code-block:: console
+.. code-block:: vim
 
     :set runtimepath
-      runtimepath=~/.config/nvim,/etc/xdg/nvim,~/.local/share/nvim/site,...,
+    runtimepath=~/.config/nvim,/etc/xdg/nvim,~/.local/share/nvim/site,...,
     ,~/g/path/to/your/plugin-git-repo
 
+    " Or alternatively
+    echo &rtp
 

--- a/docs/usage/remote-plugins.rst
+++ b/docs/usage/remote-plugins.rst
@@ -96,5 +96,4 @@ You can also inspect the ``&runtimepath`` like this:
     ,~/g/path/to/your/plugin-git-repo
 
     " Or alternatively
-    echo &rtp
-
+    :echo &rtp


### PR DESCRIPTION
Building the docs raised errors for me because the lines under the headers were too short.

In addition, a few of the code blocks weren't being properly highlighted (I.E. the bottom of <https://pynvim.readthedocs.io/en/latest/usage/remote-plugins.html> ) so I changed the lexer to signify that the code blocks are run inside of Vim and fixed the indentation and that seems to have worked for me. 