### PR TITLE
Add metadata to setup.cfg for pypi

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,7 @@
+tags
+.venv
+.pytest_cache/*
+.coverage*
 *.egg-info/
 __pycache__
 neovim/ui/screen.c

--- a/pynvim/api/nvim.py
+++ b/pynvim/api/nvim.py
@@ -354,10 +354,14 @@ class Nvim(object):
         """Push `keys` to Nvim user input buffer.
 
         Options can be a string with the following character flags:
+
         - 'm': Remap keys. This is default.
+
         - 'n': Do not remap keys.
+
         - 't': Handle keys as if typed; otherwise they are handled as if coming
                from a mapping. This matters for undo, opening folds, etc.
+
         """
         return self.request('nvim_feedkeys', keys, options, escape_csi)
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,3 +1,31 @@
+[metadata]
+classifiers =
+    Environment :: Console
+    License :: OSI Approved :: Apache License
+    Intended Audience :: Developers
+    Intended Audience :: End Users/Desktop
+    Natural Language :: English
+    Operating System :: Android
+    Operating System :: Microsoft :: Windows :: Windows 10
+    Operating System :: POSIX
+    Programming Language :: Python
+    Programming Language :: Python :: 3
+    Programming Language :: Python :: 3.5
+    Programming Language :: Python :: 3.6
+    Programming Language :: Python :: 3.7
+    Programming Language :: Python :: 3.8
+    Programming Language :: Python :: Implementation :: CPython
+    Programming Language :: Python :: Implementation :: PyPy
+
+long_description = file: README.md, LICENSE
+long_description_content_type=text/markdown
+keywords = nvim, vim, pynvim
+platforms = any
+test_suite = test
+
+[options]
+include_package_data = True
+
 [aliases]
 test = pytest
 


### PR DESCRIPTION
As it currently stands the repo's page on [pypi](https://pypi.org/project/pynvim/) doesn't include any metadata which would make it harder to find the project as well as displaying no information about it on the website.

This adds classifiers and keywords to help the project be easier to find as well as adding the README to it's description.

I also added some whitespace to one of the docstrings because building the docs were still generating a few errors, and a few simple additions to the gitignore that I needed while working on this.