### PR TITLE
test_invalid_utf8: Use distinct if/else branches

### DIFF
--- a/test/test_buffer.py
+++ b/test/test_buffer.py
@@ -164,11 +164,19 @@ def test_mark(vim):
 def test_invalid_utf8(vim):
     vim.command('normal "=printf("%c", 0xFF)\np')
     assert vim.eval("char2nr(getline(1))") == 0xFF
-    assert vim.current.buffer[:] == ['\udcff'] if IS_PYTHON3 else ['\xff']
+
+    if IS_PYTHON3:
+        assert vim.current.buffer[:] == ['\udcff']
+    else:
+        assert vim.current.buffer[:] == ['\xff']
 
     vim.current.line += 'x'
-    assert vim.eval("getline(1)", decode=False) == '\udcffx' if IS_PYTHON3 else '\xffx'
-    assert vim.current.buffer[:] == ['\udcffx'] if IS_PYTHON3 else ['\xffx']
+    if IS_PYTHON3:
+        assert vim.eval("getline(1)", decode=False) == '\udcffx'
+        assert vim.current.buffer[:] == ['\udcffx']
+    else:
+        assert vim.eval("getline(1)", decode=False) == '\xffx'
+        assert vim.current.buffer[:] == ['\xffx']
 
 
 def test_get_exceptions(vim):


### PR DESCRIPTION
pytest isn't able to report the expected value when using the `X if Y else Z` syntax.

See pytest-dev/pytest#7727