### PR TITLE
Change the data type of a Buffer so that it works correctly

### DIFF
--- a/pynvim/api/buffer.py
+++ b/pynvim/api/buffer.py
@@ -3,7 +3,7 @@ from pynvim.api.common import Remote
 from pynvim.compat import IS_PYTHON3, check_async
 
 
-__all__ = ('Buffer')
+__all__ = ['Buffer']
 
 
 if IS_PYTHON3:


### PR DESCRIPTION
```python

from pynvim.api.buffer import *

```

Doesn't correctly import Buffer. `__all__` is incorrectly defined as a tuple and as a result it tries importing each individual letter instead of the actual class.

In addition, the python reference explicitly defines that `__all__` should be a list. 