### PR TITLE
WIP: deprecate imp module

### DIFF
--- a/pynvim/compat.py
+++ b/pynvim/compat.py
@@ -2,37 +2,17 @@
 
 import sys
 import warnings
-from imp import find_module as original_find_module
 
 
 IS_PYTHON3 = sys.version_info >= (3, 0)
 
 
 if IS_PYTHON3:
-    def find_module(fullname, path):
-        """Compatibility wrapper for imp.find_module.
-
-        Automatically decodes arguments of find_module, in Python3
-        they must be Unicode
-        """
-        if isinstance(fullname, bytes):
-            fullname = fullname.decode()
-        if isinstance(path, bytes):
-            path = path.decode()
-        elif isinstance(path, list):
-            newpath = []
-            for element in path:
-                if isinstance(element, bytes):
-                    newpath.append(element.decode())
-                else:
-                    newpath.append(element)
-            path = newpath
-        return original_find_module(fullname, path)
-
     # There is no 'long' type in Python3 just int
     long = int
     unicode_errors_default = 'surrogateescape'
 else:
+    from imp import find_module as original_find_module
     find_module = original_find_module
     unicode_errors_default = 'ignore'
 

--- a/pynvim/plugin/script_host.py
+++ b/pynvim/plugin/script_host.py
@@ -100,7 +100,7 @@ class ScriptHost(object):
     def python_execute_file(self, file_path, range_start, range_stop):
         """Handle the `pyfile` ex command."""
         self._set_current_range(range_start, range_stop)
-        with open(file_path) as f:
+        with open(file_path, 'rb') as f:
             script = compile(f.read(), file_path, 'exec')
             try:
                 exec(script, self.module.__dict__)

--- a/pynvim/plugin/script_host.py
+++ b/pynvim/plugin/script_host.py
@@ -1,5 +1,4 @@
 """Legacy python/python3-vim emulation."""
-import imp
 import io
 import logging
 import os
@@ -214,6 +213,7 @@ def path_hook(nvim):
         return discover_runtime_directories(nvim)
 
     def _find_module(fullname, oldtail, path):
+        import imp
         idx = oldtail.find('.')
         if idx > 0:
             name = oldtail[:idx]
@@ -234,6 +234,7 @@ def path_hook(nvim):
                 return sys.modules[fullname]
             except KeyError:
                 pass
+            import imp
             return imp.load_module(fullname, *self.module)
 
     class VimPathFinder(object):

--- a/pynvim/util.py
+++ b/pynvim/util.py
@@ -39,4 +39,4 @@ def get_client_info(kind, type_, method_spec):
     return (name, VERSION.__dict__, type_, method_spec, attributes)
 
 
-VERSION = Version(major=0, minor=4, patch=2, prerelease='')
+VERSION = Version(major=0, minor=4, patch=3, prerelease='')

--- a/setup.py
+++ b/setup.py
@@ -35,10 +35,10 @@ if platform.python_implementation() != 'PyPy':
     install_requires.append('greenlet')
 
 setup(name='pynvim',
-      version='0.4.2',
+      version='0.4.3',
       description='Python client to neovim',
       url='http://github.com/neovim/pynvim',
-      download_url='https://github.com/neovim/pynvim/archive/0.4.2.tar.gz',
+      download_url='https://github.com/neovim/pynvim/archive/0.4.3.tar.gz',
       author='Thiago de Arruda',
       author_email='tpadilha84@gmail.com',
       license='Apache',


### PR DESCRIPTION
Since there are no reasonable alternatives to imp in python2.7,
I figured it'd be the easiest to try importing python3 modules and if
that fails, fall back to the previous method. However this will remove
that annoying DeprecationWarning for everyone using python3.