### PR TITLE
docs: fix a few simple typos

### DIFF
--- a/docs/usage/python-plugin-api.rst
+++ b/docs/usage/python-plugin-api.rst
@@ -86,7 +86,7 @@ root, and use ``vim.exec_lua("_testplugin = require('testplugin')")``.
 In both cases, replace ``testplugin`` with a unique string based on your plugin
 name.
 
-Then, the module can be acessed as ``vim.lua._testplugin``.
+Then, the module can be accessed as ``vim.lua._testplugin``.
 
 .. code-block:: python
 

--- a/pynvim/__init__.py
+++ b/pynvim/__init__.py
@@ -98,12 +98,12 @@ def attach(session_type, address=None, port=None,
     When the session is not needed anymore, it is recommended to explicitly
     close it:
        nvim.close()
-    It is also possible to use the session as a context mangager:
+    It is also possible to use the session as a context manager:
        with attach('socket', path=thepath) as nvim:
            print(nvim.funcs.getpid())
            print(nvim.current.line)
     This will automatically close the session when you're done with it, or
-    when an error occured.
+    when an error occurred.
 
 
     """

--- a/pynvim/api/buffer.py
+++ b/pynvim/api/buffer.py
@@ -37,7 +37,7 @@ class Buffer(Remote):
         buffer. For example, -1 is the last line, -2 is the line before that
         and so on.
 
-        When retrieving slices, omiting indexes(eg: `buffer[:]`) will bring
+        When retrieving slices, omitting indexes(eg: `buffer[:]`) will bring
         the whole buffer.
         """
         if not isinstance(idx, slice):
@@ -52,7 +52,7 @@ class Buffer(Remote):
 
         Like with `__getitem__`, indexes may be negative.
 
-        When replacing slices, omiting indexes(eg: `buffer[:]`) will replace
+        When replacing slices, omitting indexes(eg: `buffer[:]`) will replace
         the whole buffer.
         """
         if not isinstance(idx, slice):
@@ -69,7 +69,7 @@ class Buffer(Remote):
 
         This will retrieve all lines locally before iteration starts. This
         approach is used because for most cases, the gain is much greater by
-        minimizing the number of API calls by transfering all data needed to
+        minimizing the number of API calls by transferring all data needed to
         work.
         """
         lines = self[:]

--- a/pynvim/msgpack_rpc/async_session.py
+++ b/pynvim/msgpack_rpc/async_session.py
@@ -50,7 +50,7 @@ class AsyncSession(object):
 
         A msgpack-rpc with method `method` and argument `args` is sent to
         Nvim. This will have the same effect as a request, but no response
-        will be recieved
+        will be received
         """
         self._msgpack_stream.send([2, method, args])
 

--- a/scripts/logging_statement_modifier.py
+++ b/scripts/logging_statement_modifier.py
@@ -264,7 +264,7 @@ def modify_logging(input_fn, output_fn, min_level_value, max_level_value, restor
 
 def check_level(logging_stmt, logging_stmt_is_commented_out, min_level_value, max_level_value):
     """Extracts the level of the logging statement and returns True if the
-    level falls betwen min and max_level_value.  If the level cannot be
+    level falls between min and max_level_value.  If the level cannot be
     extracted, then a warning is logged."""
     level = get_logging_level(logging_stmt, logging_stmt_is_commented_out)
     if level is None:

--- a/test/test_decorators.py
+++ b/test/test_decorators.py
@@ -15,7 +15,7 @@ def test_command_count():
     decorated = command('test', count=count_value)(function)
     assert 'count' not in decorated._nvim_rpc_spec['opts']
 
-    # Test presesence with value of 0
+    # Test precedence with value of 0
     count_value = 0
     decorated = command('test', count=count_value)(function)
     assert 'count' in decorated._nvim_rpc_spec['opts']


### PR DESCRIPTION
There are small typos in:
- docs/usage/python-plugin-api.rst
- pynvim/__init__.py
- pynvim/api/buffer.py
- pynvim/msgpack_rpc/async_session.py
- scripts/logging_statement_modifier.py
- test/test_decorators.py

Closes #487