### PR TITLE
Add explicit API function definitions

### DIFF
--- a/pynvim/api/__init__.py
+++ b/pynvim/api/__init__.py
@@ -8,8 +8,8 @@ from pynvim.api.buffer import Buffer
 from pynvim.api.common import decode_if_bytes, walk
 from pynvim.api.nvim import Nvim, NvimError
 from pynvim.api.tabpage import Tabpage
-from pynvim.api.window import Window
+from pynvim.api.window import Window, WindowConfig
 
 
 __all__ = ('Nvim', 'Buffer', 'Window', 'Tabpage', 'NvimError',
-           'decode_if_bytes', 'walk')
+           'decode_if_bytes', 'walk', 'WindowConfig')

--- a/pynvim/api/buffer.py
+++ b/pynvim/api/buffer.py
@@ -1,6 +1,6 @@
 """API for working with a Nvim Buffer."""
-from typing import (Any, Iterator, List, Optional, TYPE_CHECKING, Tuple, Union, cast,
-                    overload)
+from typing import (Any, Dict, Iterator, List, Optional, Sequence, TYPE_CHECKING, Tuple,
+                    Union, cast, overload)
 
 from pynvim.api.common import Remote
 from pynvim.compat import check_async
@@ -190,10 +190,26 @@ class Buffer(Remote):
             "nvim_buf_clear_highlight", src_id, line_start, line_end, async_=async_
         )
 
+    def clear_namespace(
+        self,
+        src_id: int,
+        line_start: int = 0,
+        line_end: int = -1,
+        async_: bool = None,
+    ) -> None:
+        """Clear namespaced objects (highlights, extmarks, virtual text)."""
+        self.request(
+            "nvim_buf_clear_namespace", src_id, line_start, line_end, async_=async_
+        )
+
+    def del_keymap(self, mode: str, lhs: str) -> None:
+        """Unmaps a buffer-local mapping for the given mode."""
+        return self.request('nvim_buf_del_keymap', mode, lhs)
+
     def update_highlights(
         self,
         src_id: int,
-        hls: List[Union[Tuple[str, int], Tuple[str, int, int, int]]],
+        hls: Sequence[Union[Tuple[str, int, int, int], Tuple[str, int]]],
         clear_start: Optional[int] = None,
         clear_end: int = -1,
         clear: bool = False,
@@ -218,6 +234,26 @@ class Buffer(Remote):
             clear_start = 0
         lua = self._session._get_lua_private()
         lua.update_highlights(self, src_id, hls, clear_start, clear_end, async_=async_)
+
+    def set_virtual_text(
+        self,
+        line: int,
+        chunks: Sequence[Union[Tuple[str, str], Tuple[str]]],
+        src_id: int = -1,
+        opts: Dict[str, Any] = None
+    ) -> None:
+        """Set the virtual text (annotation) for a buffer line."""
+        if opts is None:
+            opts = {}
+        return self.request("nvim_buf_set_virtual_text", src_id, line, chunks, opts)
+
+    def set_keymap(
+        self, mode: str, lhs: str, rhs: str, opts: Dict[str, bool] = None
+    ) -> None:
+        """Sets a buffer-local mapping for the given mode."""
+        if opts is None:
+            opts = {}
+        return self.request("nvim_buf_set_keymap", mode, lhs, rhs, opts)
 
     @property
     def name(self) -> str:

--- a/pynvim/api/window.py
+++ b/pynvim/api/window.py
@@ -1,14 +1,52 @@
 """API for working with Nvim windows."""
-from typing import TYPE_CHECKING, Tuple, cast
+import sys
+from typing import TYPE_CHECKING, Tuple, Union, cast
 
 from pynvim.api.buffer import Buffer
 from pynvim.api.common import Remote
+
+if sys.version_info < (3, 8):
+    from typing_extensions import Literal, TypedDict
+else:
+    from typing import Literal, TypedDict
 
 if TYPE_CHECKING:
     from pynvim.api.tabpage import Tabpage
 
 
 __all__ = ['Window']
+
+TWinChar = Union[str, Tuple[str, str]]
+TWinManualBorder = Tuple[TWinChar, TWinChar, TWinChar, TWinChar,
+                         TWinChar, TWinChar, TWinChar, TWinChar]
+TWinBorder = Union[
+    Literal['none'],
+    Literal['single'],
+    Literal['double'],
+    Literal['rounded'],
+    Literal['solid'],
+    Literal['shadow'],
+    TWinManualBorder,
+]
+TWinRelative = Union[Literal[''], Literal['editor'], Literal['win'], Literal['cursor']]
+TWinAnchor = Union[Literal['NW'], Literal['NE'], Literal['SW'], Literal['SE']]
+
+
+class WindowConfig(TypedDict, total=False):
+    relative: TWinRelative
+    focusable: bool
+    external: bool
+    win: 'Window'
+    anchor: TWinAnchor
+    width: int
+    height: int
+    bufpos: Tuple[int, int]
+    row: Union[int, float]
+    col: Union[int, float]
+    zindex: int
+    style: Literal['minimal']
+    border: TWinBorder
+    noautocmd: bool
 
 
 class Window(Remote):
@@ -21,6 +59,11 @@ class Window(Remote):
     def buffer(self) -> Buffer:
         """Get the `Buffer` currently being displayed by the window."""
         return self.request('nvim_win_get_buf')
+
+    @buffer.setter
+    def buffer(self, buffer: Union[int, Buffer]) -> None:
+        """Set the `Buffer` to be displayed by the window."""
+        return self.request('nvim_win_set_buf', buffer)
 
     @property
     def cursor(self) -> Tuple[int, int]:
@@ -76,3 +119,21 @@ class Window(Remote):
     def number(self) -> int:
         """Get the window number."""
         return self.request('nvim_win_get_number')
+
+    def close(self, force: bool) -> None:
+        """Close the window."""
+        return self.request('nvim_win_close', force)
+
+    def hide(self) -> None:
+        """Close the window and hide the buffer it contains."""
+        return self.request('nvim_win_hide')
+
+    @property
+    def config(self) -> WindowConfig:
+        """Gets the window configuration."""
+        return self.request('nvim_win_get_config')
+
+    @config.setter
+    def config(self, config: WindowConfig) -> None:
+        """Configures the window layout."""
+        return self.request('nvim_win_set_config', config)


### PR DESCRIPTION
Depends on #492 

With the addition of type annotations, there is now a reason to explicitly enumerate the API methods instead of relying on the magic `__getattr__`. If they are explicitly provided, plugin authors will get better autocompletion (via LSP) and more type safety guarantees.

Since this depends on #492, it has all of its commits. I'll rebase it once merged, but if anyone knows of a better Github workflow for dependent PR's, please let me know.