### PR TITLE
Fix: evaluate v:true/v:false to python bool type

### DIFF
--- a/pynvim/plugin/script_host.py
+++ b/pynvim/plugin/script_host.py
@@ -194,7 +194,7 @@ else:
 
 
 def num_to_str(obj):
-    if isinstance(obj, num_types):
+    if isinstance(obj, num_types) and not isinstance(obj, bool):
         return str(obj)
     else:
         return obj

--- a/test/test_host.py
+++ b/test/test_host.py
@@ -28,3 +28,10 @@ def test_host_async_error(vim):
     assert event[1] == 'nvim_error_event'
     assert 'rplugin-host: Async request caused an error:\nboom\n' \
            in h._on_error_event(None, 'boom')
+
+def test_legacy_vim_eval(vim):
+    h = ScriptHost(vim)
+    assert h.legacy_vim.eval('1') == '1'
+    assert h.legacy_vim.eval('v:null') == None
+    assert h.legacy_vim.eval('v:true') == True
+    assert h.legacy_vim.eval('v:false') == False


### PR DESCRIPTION
This PR fixes an issue that when calling `vim.eval('v:true')`, or `vim.eval('v:false')`, it gives the wrong `str` type.

In the latest version of `vim`, when executing below Ex command, the result is `<class 'bool'>`. But in `neovim`, it is `<class 'str'>`.

```
:py3 print(type(vim.eval('v:true')))
```