### PR TITLE
Fix `Unknown config option: timout` warning

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -13,7 +13,6 @@ known_first_party = pynvim
 
 [tool:pytest]
 testpaths = test
-timeout = 10
 
 [mypy]
 disallow_untyped_calls = true


### PR DESCRIPTION
This option is no longer valid with pytest 6+

```
========================================================= warnings summary =========================================================
.venv311/lib64/python3.11/site-packages/_pytest/config/__init__.py:1373
  /home/michel/src/github/neovim/pynvim/.venv311/lib64/python3.11/site-packages/_pytest/config/__init__.py:1373: PytestConfigWarning: Unknown config option: timeout

    self._warn_or_fail_if_strict(f"Unknown config option: {key}\n")

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
```

See e.g. https://github.com/samuelcolvin/rtoml/issues/12