### PR TITLE
test_buffer: don't depend on version-dependent default values of 'define'

### DIFF
--- a/test/test_buffer.py
+++ b/test/test_buffer.py
@@ -103,10 +103,11 @@ def test_options(vim: Nvim) -> None:
     vim.current.buffer.options['shiftwidth'] = 4
     assert vim.current.buffer.options['shiftwidth'] == 4
     # global-local option
+    global_define = vim.options['define']
     vim.current.buffer.options['define'] = 'test'
     assert vim.current.buffer.options['define'] == 'test'
     # Doesn't change the global value
-    assert vim.options['define'] == ''
+    assert vim.options['define'] == global_define
 
     with pytest.raises(KeyError) as excinfo:
         vim.current.buffer.options['doesnotexist']


### PR DESCRIPTION
`test_options` has an assertion that tests whether setting a local value modifies the global value, but tests it against a hardcoded constant.

This constant changed in https://github.com/neovim/neovim/commit/fcfe535e9877cfdc824dc78f2d19e590400d34cd

and
https://github.com/neovim/pynvim/commit/82a2e14b96fbffa30caeefec6e86b668c96662eb fixes it by using the new constant instead, but this causes tests to fail against even the latest released version of neovim.

To make this version-agnostic, save the old global value, and assert that the new value is equal after setting the local value.