### PR TITLE
fix: fix broken dynamic import of rplugin modules

### DIFF
--- a/test/fixtures/module_plugin/rplugin/python3/mymodule/__init__.py
+++ b/test/fixtures/module_plugin/rplugin/python3/mymodule/__init__.py
@@ -1,0 +1,9 @@
+"""The `mymodule` package for the fixture module plugin."""
+# pylint: disable=all
+
+# Somehow the plugin might be using relative imports.
+from .plugin import MyPlugin as MyPlugin
+
+# ... or absolute import (assuming this is the root package)
+import mymodule.plugin  # noqa: I100
+assert mymodule.plugin.MyPlugin is MyPlugin

--- a/test/fixtures/module_plugin/rplugin/python3/mymodule/plugin.py
+++ b/test/fixtures/module_plugin/rplugin/python3/mymodule/plugin.py
@@ -1,0 +1,13 @@
+"""Actual implement lies here."""
+import pynvim as neovim
+import pynvim.api
+
+
+@neovim.plugin
+class MyPlugin:
+    def __init__(self, nvim: pynvim.api.Nvim):
+        self.nvim = nvim
+
+    @neovim.command("ModuleHelloWorld")
+    def hello_world(self) -> None:
+        self.nvim.command("echom 'MyPlugin: Hello World!'")

--- a/test/fixtures/simple_plugin/rplugin/python3/simple_nvim.py
+++ b/test/fixtures/simple_plugin/rplugin/python3/simple_nvim.py
@@ -1,0 +1,13 @@
+import neovim
+
+import pynvim.api
+
+
+@neovim.plugin
+class SimplePlugin:
+    def __init__(self, nvim: pynvim.api.Nvim):
+        self.nvim = nvim
+
+    @neovim.command("SimpleHelloWorld")
+    def hello_world(self) -> None:
+        self.nvim.command("echom 'SimplePlugin: Hello World!'")

--- a/test/test_host.py
+++ b/test/test_host.py
@@ -1,7 +1,12 @@
-# -*- coding: utf-8 -*-
 # type: ignore
+# pylint: disable=protected-access
+import os
+from typing import Sequence
+
 from pynvim.plugin.host import Host, host_method_spec
 from pynvim.plugin.script_host import ScriptHost
+
+__PATH__ = os.path.abspath(os.path.dirname(__file__))
 
 
 def test_host_imports(vim):
@@ -9,6 +14,24 @@ def test_host_imports(vim):
     assert h.module.__dict__['vim']
     assert h.module.__dict__['vim'] == h.legacy_vim
     assert h.module.__dict__['sys']
+
+
+def test_host_import_rplugin_modules(vim):
+    # Test whether a Host can load and import rplugins (#461).
+    # See also $VIMRUNTIME/autoload/provider/pythonx.vim.
+    h = Host(vim)
+    plugins: Sequence[str] = [  # plugin paths like real rplugins
+        os.path.join(__PATH__, "./fixtures/simple_plugin/rplugin/python3/simple_nvim.py"),
+        os.path.join(__PATH__, "./fixtures/module_plugin/rplugin/python3/mymodule/"),
+        os.path.join(__PATH__, "./fixtures/module_plugin/rplugin/python3/mymodule"),  # duplicate
+    ]
+    h._load(plugins)
+    assert len(h._loaded) == 2
+
+    # pylint: disable-next=unbalanced-tuple-unpacking
+    simple_nvim, mymodule = list(h._loaded.values())
+    assert simple_nvim['module'].__name__ == 'simple_nvim'
+    assert mymodule['module'].__name__ == 'mymodule'
 
 
 def test_host_clientinfo(vim):


### PR DESCRIPTION
The removal of `imp` package (#461) in order to supprot Python 3.12 had a bug where rplugins can't be loaded and the ImportError exception was silenced, making the remote provider throwing lots of errors. This commit fixes broken dynamic import of python modules from the registered rplugins.

We add tests for Host._load, with loading rplugins consisting of:

  (1) single-file module  (e.g., `rplugins/simple_plugin.py`)
  (2) package (e.g., `rplugins/mymodule/__init__.py`)


Note: As per https://docs.python.org/3.12/whatsnew/3.12.html#imp, I also tried something like:

```python
def _handle_import(path, name):
    # First try to import module
    spec = importlib.machinery.PathFinder.find_spec(name, [path])

    # or single-file package
    if spec is None:
        filename = os.path.join(path, name + '.py')
        loader = importlib.machinery.SourceFileLoader(name, filename)
        spec = importlib.util.spec_from_file_location(
            name, location=filename, loader=loader)

    if spec is not None:
        mod = importlib.util.module_from_spec(spec)
        spec.loader.exec_module(mod)
        return mod
    raise ImportError(name=name, path=path)
```
but this fails to resolve relative import within the package to unlike the previous implementation using `imp` (see the unit test fixtures). Possible more addition of `loader` would be needed. If you think this is the right way, please let me know so we can have additional work. Actually the remote host python should be able to import packages, so I don't see any reason why we couldn't use the approach of manipulating `sys.path` and import the module.