### PR TITLE
ci: Add python3.12 support

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -22,7 +22,7 @@ jobs:
         cache: 'pip'
         python-version: 3.11
     - name: install dependencies
-      run: pip install tox tox-gh-actions
+      run: python3 -m pip install tox tox-gh-actions
     - name: checkqa
       env:
         TOXENV: 'checkqa,docs'
@@ -32,7 +32,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python: ['3.10', '3.11']
+        python: ['3.10', '3.11', '3.12-dev']
         os: ['ubuntu-latest', 'macos-latest', 'windows-latest']
         include:
         - os: ubuntu-latest
@@ -71,11 +71,13 @@ jobs:
       run: echo "$(pwd)/${{ matrix.NVIM_BIN_PATH }}" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
 
     - name: install dependencies
-      run: pip install tox tox-gh-actions
+      run: python3 -m pip install tox tox-gh-actions
 
-    - name: test
+    - name: test with tox
       run: |
         echo $PATH
         which nvim
         nvim --version
+        which -a python3
+        python3 --version
         tox

--- a/setup.py
+++ b/setup.py
@@ -24,7 +24,10 @@ extras_require = {
 
 if platform.python_implementation() != 'PyPy':
     # pypy already includes an implementation of the greenlet module
-    install_requires.append('greenlet')
+    if sys.version_info >= (3, 12):
+        install_requires.append('greenlet>=3.0.0rc3')
+    else:
+        install_requires.append('greenlet')
 
 if sys.version_info < (3, 8):
     install_requires.append('typing-extensions')

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -13,7 +13,10 @@ def vim() -> pynvim.Nvim:
     child_argv = os.environ.get('NVIM_CHILD_ARGV')
     listen_address = os.environ.get('NVIM_LISTEN_ADDRESS')
     if child_argv is None and listen_address is None:
-        child_argv = '["nvim", "-u", "NONE", "--embed", "--headless"]'
+        child_argv = json.dumps([
+            "nvim", "-u", "NONE", "--embed", "--headless",
+            "-c", "let g:python3_host_prog='python3'",  # workaround neovim/neovim#25316
+        ])
 
     if child_argv is not None:
         editor = pynvim.attach('child', argv=json.loads(child_argv))

--- a/test/test_vim.py
+++ b/test/test_vim.py
@@ -197,7 +197,11 @@ def test_hash(vim: Nvim) -> None:
     assert d[vim.current.buffer] == 'beta'
 
 
-def test_cwd(vim: Nvim, tmpdir: Any) -> None:
+def test_python3(vim: Nvim, tmpdir: Any) -> None:
+    python3_prog = vim.command_output('echom provider#python3#Prog()')
+    python3_err = vim.command_output('echom provider#python3#Error()')
+    assert python3_prog != "", python3_err
+
     vim.command('python3 import os')
     cwd_before = vim.command_output('python3 print(os.getcwd())')
 


### PR DESCRIPTION
neovim's python3 provider detection has a bug on python3.12
(neovim/neovim#25316), so we work around this by explicitly setting
the `g:python3_host_prog` variable.

Also, pynvim on python3.12 requires greenlet 3.x.

Fixes #528
