### PR TITLE
ci: Run CI and tox test for all supported python versions 3.7+

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,9 +9,6 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.event_name == 'pull_request' && github.head_ref || github.repository_owner == 'neovim' && github.sha || github.ref_name }}
   cancel-in-progress: true
 
-env:
-  PYTEST_ADDOPTS: '-vv'
-
 jobs:
   lint:
     runs-on: ubuntu-latest
@@ -24,17 +21,30 @@ jobs:
     - name: install dependencies
       run: python3 -m pip install tox tox-gh-actions
     - name: checkqa
-      env:
-        TOXENV: 'checkqa,docs'
-      run: tox
+      run: tox run -e checkqa,docs
 
   test:
     strategy:
       fail-fast: false
       matrix:
-        python: ['3.10', '3.11', '3.12-dev']
+        python-version: ['3.10', '3.11', '3.12-dev']
         os: ['ubuntu-latest', 'macos-latest', 'windows-latest']
         include:
+        - os: ubuntu-20.04
+          python-version: '3.7'
+          NIGHTLY: nvim-linux64.tar.gz
+          NVIM_BIN_PATH: nvim-linux64/bin
+          EXTRACT: tar xzf
+        - os: ubuntu-latest
+          python-version: '3.8'
+          NIGHTLY: nvim-linux64.tar.gz
+          NVIM_BIN_PATH: nvim-linux64/bin
+          EXTRACT: tar xzf
+        - os: ubuntu-latest
+          python-version: '3.9'
+          NIGHTLY: nvim-linux64.tar.gz
+          NVIM_BIN_PATH: nvim-linux64/bin
+          EXTRACT: tar xzf
         - os: ubuntu-latest
           NIGHTLY: nvim-linux64.tar.gz
           NVIM_BIN_PATH: nvim-linux64/bin
@@ -54,7 +64,7 @@ jobs:
     - uses: actions/setup-python@v4
       with:
         cache: 'pip'
-        python-version: ${{ matrix.python }}
+        python-version: ${{ matrix.python-version }}
 
     - name: install neovim
       run: |
@@ -71,7 +81,9 @@ jobs:
       run: echo "$(pwd)/${{ matrix.NVIM_BIN_PATH }}" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
 
     - name: install dependencies
-      run: python3 -m pip install tox tox-gh-actions
+      run: |
+        python3 -m pip install -U pip
+        python3 -m pip install tox tox-gh-actions
 
     - name: test with tox
       run: |
@@ -80,4 +92,4 @@ jobs:
         nvim --version
         which -a python3
         python3 --version
-        tox
+        tox run

--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ See the [Python Plugin API](http://pynvim.readthedocs.io/en/latest/usage/python-
 Development
 -----------
 
-Use (and activate) a local virtualenv.
+Use (and activate) a local virtualenv, for example:
 
     python3 -m virtualenv venv
     source venv/bin/activate

--- a/docs/development.rst
+++ b/docs/development.rst
@@ -6,6 +6,7 @@ If you change the code, you need to run::
     pip3 install .
 
 for the changes to have effect.
+
 Alternatively you could execute Neovim with the ``$PYTHONPATH`` environment variable::
 
     PYTHONPATH=/path/to/pynvim nvim
@@ -25,7 +26,7 @@ directory added to ``sys.path``.
 
 If you want to test a different version than ``nvim`` in ``$PATH`` use::
 
-    NVIM_CHILD_ARGV='["/path/to/nvim", "-u", "NONE", "--embed", "--headless"]' pytest
+    NVIM_CHILD_ARGV='["/path/to/nvim", "--clean", "--embed", "--headless"]' pytest
 
 Alternatively, if you want to see the state of nvim, you could use::
 
@@ -35,6 +36,24 @@ Alternatively, if you want to see the state of nvim, you could use::
 
 But note you need to restart Neovim every time you run the tests!
 Substitute your favorite terminal emulator for ``xterm``.
+
+Contributing
+------------
+
+Before submitting any pull requests, please run linters and tests if possible.
+
+In the CI we run `flake8` and `mypy`:
+
+    flake8 pynvim test
+    mypy pynvim test
+
+If you have `tox`_, you can test with multiple python versions locally:
+
+    tox run                      # run on all available python environments
+    tox run -e py311,checkqa     # run on python3.11, and linters
+    tox run --parallell          # run everything in parallel
+
+.. _`tox`: https://tox.wiki/
 
 Troubleshooting
 ---------------

--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ setup_requires = [
 ] + pytest_runner,
 
 tests_require = [
-    'pytest>=3.4.0',
+    'pytest',
 ]
 
 extras_require = {
@@ -43,7 +43,7 @@ setup(name='pynvim',
       packages=['pynvim', 'pynvim.api', 'pynvim.msgpack_rpc',
                 'pynvim.msgpack_rpc.event_loop', 'pynvim.plugin',
                 'neovim', 'neovim.api'],
-      python_requires=">=3.6",
+      python_requires=">=3.7",
       install_requires=install_requires,
       setup_requires=setup_requires,
       tests_require=tests_require,

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -14,7 +14,11 @@ def vim() -> pynvim.Nvim:
     listen_address = os.environ.get('NVIM_LISTEN_ADDRESS')
     if child_argv is None and listen_address is None:
         child_argv = json.dumps([
-            "nvim", "-u", "NONE", "--embed", "--headless",
+            "nvim",
+            "--clean",  # no config and plugins (-u NONE), no SHADA
+            "-n",  # no swap file
+            "--embed",
+            "--headless",
             "-c", "let g:python3_host_prog='python3'",  # workaround neovim/neovim#25316
         ])
 

--- a/tox.ini
+++ b/tox.ini
@@ -1,12 +1,23 @@
+# https://tox.wiki/en/stable/config.html
+# Note: to run individual jobs locally, do "tox run -e py310,311"
+
 [tox]
+min_version = 4.0
 envlist =
-  py{310,311}-asyncio
+  py{37,38,39,310,311,312}-asyncio
   checkqa
+skip_missing_interpreters =
+  true
 
 [gh-actions]
+# https://github.com/ymyzk/tox-gh-actions
 python =
+  3.7: py37
+  3.8: py38
+  3.9: py39
   3.10: py310
   3.11: py311
+  3.12: py312
   pypy3: pypy3
 
 [testenv]
@@ -17,9 +28,9 @@ deps =
 # pyuv: pyuv
 # setenv =
 #   cov: PYTEST_ADDOPTS=--cov=. {env:PYTEST_ADDOPTS:}
-passenv = PYTEST_ADDOPTS
+# passenv = PYTEST_ADDOPTS
 commands =
-  python -m pytest {posargs}
+  python3 -m pytest --color yes -s -vv {posargs}
 
 [testenv:checkqa]
 deps =
@@ -30,6 +41,7 @@ deps =
   pep8-naming
   msgpack-types
 ignore_errors = true
+# see also: docs/development.rst
 commands =
   flake8 {posargs:pynvim test}
   mypy --show-error-codes {posargs:pynvim test}


### PR DESCRIPTION
- Include python 3.7, 3.8, and 3.9 as well to the Github CI actions.

- Configure tox to run tests on python3.7-python3.12 (skip if python
  interpreters are not found on local environments).

- Add "Contributing" section to docs/development, suggesting how to run
  tests locally.

- Unify the way how we specify pytest options (`-s -vv`) into tox.ini.

- Bump up `python_requires` to 3.7 in the package spec.

- Make sure to use `nvim --clean` to against flaky tests. No SHADA and
  swapfiles should be used.
