### PR TITLE
packaging: add pynvim.__version__ attribute (0.5.0.dev0)

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ connecting to and scripting Nvim processes through its msgpack-rpc API.
 Install
 -------
 
-Supports python 3.10 or later.
+Supports python 3.7 or later.
 
     pip3 install pynvim
 
@@ -115,7 +115,7 @@ Release
 
 1. Create a release commit with title `Pynvim x.y.z`
    - list significant changes in the commit message
-   - bump the version in `pynvim/util.py` and `setup.py` (3 places in total)
+   - bump the version in `pynvim/_version.py`
 2. Make a release on GitHub with the same commit/version tag and copy the message.
 3. Run `scripts/disable_log_statements.sh`
 4. Run `python -m build`
@@ -123,6 +123,7 @@ Release
 5. Run `twine upload -r pypi dist/*`
     - Assumes you have a pypi account with permissions.
 6. Run `scripts/enable_log_statements.sh` or `git reset --hard` to restore the working dir.
+7. Bump up to the next development version in `pynvim/_version.py`, with `prerelease` suffix `dev0`.
 
 License
 -------

--- a/pynvim/__init__.py
+++ b/pynvim/__init__.py
@@ -8,12 +8,13 @@ import sys
 from types import SimpleNamespace as Version
 from typing import List, Optional, cast, overload
 
+from pynvim._version import VERSION, __version__
 from pynvim.api import Nvim, NvimError
-from pynvim.msgpack_rpc import (ErrorResponse, Session, TTransportType, child_session,
-                                socket_session, stdio_session, tcp_session)
+from pynvim.msgpack_rpc import (ErrorResponse, Session, TTransportType,
+                                child_session, socket_session, stdio_session,
+                                tcp_session)
 from pynvim.plugin import (Host, autocmd, command, decode, encoding, function,
                            plugin, rpc_export, shutdown_hook)
-from pynvim.util import VERSION
 
 if sys.version_info < (3, 8):
     from typing_extensions import Literal
@@ -24,8 +25,9 @@ else:
 __all__ = ('tcp_session', 'socket_session', 'stdio_session', 'child_session',
            'start_host', 'autocmd', 'command', 'encoding', 'decode',
            'function', 'plugin', 'rpc_export', 'Host', 'Nvim', 'NvimError',
-           'Version', 'VERSION', 'shutdown_hook', 'attach', 'setup_logging',
-           'ErrorResponse')
+           'Version', 'VERSION', '__version__',
+           'shutdown_hook', 'attach', 'setup_logging', 'ErrorResponse',
+           )
 
 
 def start_host(session: Optional[Session] = None) -> None:

--- a/pynvim/_version.py
+++ b/pynvim/_version.py
@@ -1,0 +1,13 @@
+"""Specifies pynvim version."""
+# pylint: disable=consider-using-f-string
+
+from types import SimpleNamespace
+
+# see also setup.py
+VERSION = SimpleNamespace(major=0, minor=5, patch=0, prerelease="dev0")
+
+# e.g. "0.5.0", "0.5.0.dev0" (PEP-440)
+__version__ = '{major}.{minor}.{patch}'.format(**vars(VERSION))
+
+if VERSION.prerelease:
+    __version__ += '.' + VERSION.prerelease

--- a/pynvim/util.py
+++ b/pynvim/util.py
@@ -2,8 +2,9 @@
 
 import sys
 from traceback import format_exception
-from types import SimpleNamespace
 from typing import Any, Dict, Optional, Tuple, TypeVar
+
+from pynvim._version import VERSION
 
 
 def format_exc_skip(skip: int, limit: Optional[int] = None) -> str:
@@ -26,6 +27,3 @@ def get_client_info(
     name = "python{}-{}".format(sys.version_info[0], kind)
     attributes = {"license": "Apache v2", "website": "github.com/neovim/pynvim"}
     return (name, VERSION.__dict__, type_, method_spec, attributes)
-
-
-VERSION = SimpleNamespace(major=0, minor=4, patch=3, prerelease="")

--- a/setup.py
+++ b/setup.py
@@ -1,5 +1,10 @@
+"""setup.py for pynvim."""
+
+import os.path
 import platform
 import sys
+
+__PATH__ = os.path.abspath(os.path.dirname(__file__))
 
 from setuptools import setup
 
@@ -11,7 +16,7 @@ needs_pytest = {'pytest', 'test', 'ptr'}.intersection(sys.argv)
 pytest_runner = ['pytest-runner'] if needs_pytest else []
 
 setup_requires = [
-] + pytest_runner,
+] + pytest_runner
 
 tests_require = [
     'pytest',
@@ -29,13 +34,21 @@ if platform.python_implementation() != 'PyPy':
 if sys.version_info < (3, 8):
     install_requires.append('typing-extensions')
 
+
+# __version__: see pynvim/_version.py
+with open(os.path.join(__PATH__, "pynvim/_version.py"),
+          "r", encoding="utf-8") as fp:
+    _version_env = {}
+    exec(fp.read(), _version_env)  # pylint: disable=exec-used
+    version = _version_env['__version__']
+
+
 setup(name='pynvim',
-      version='0.4.3',
+      version=version,
       description='Python client for Neovim',
       url='http://github.com/neovim/pynvim',
-      download_url='https://github.com/neovim/pynvim/archive/0.4.3.tar.gz',
-      author='Thiago de Arruda',
-      author_email='tpadilha84@gmail.com',
+      download_url=f'https://github.com/neovim/pynvim/archive/{version}.tar.gz',
+      author='Neovim Authors',
       license='Apache',
       packages=['pynvim', 'pynvim.api', 'pynvim.msgpack_rpc',
                 'pynvim.msgpack_rpc.event_loop', 'pynvim.plugin',

--- a/test/test_version.py
+++ b/test/test_version.py
@@ -1,0 +1,7 @@
+import pynvim
+
+
+def test_version() -> None:
+    assert pynvim.__version__
+    assert isinstance(pynvim.__version__, str)
+    print(f"pynvim.__version__ = '{pynvim.__version__}'")


### PR DESCRIPTION
pynvim previously did not have the `pynvim.__version__` attribute,
which is a popular convention for python modules.

We add the `pynvim.__version__` string in addition to `pynvim.VERSION`,
and let `pynvim._version` be the only file that contains the version
metadata for the pynvim package. `setup.py` can also get the version
string from this file.

pynvim version is bumped up to 0.5.0.dev0 (from 0.4.3).
