### PR TITLE
chore: use greenlet >= 3.0

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -24,10 +24,7 @@ extras_require = {
 
 if platform.python_implementation() != 'PyPy':
     # pypy already includes an implementation of the greenlet module
-    if sys.version_info >= (3, 12):
-        install_requires.append('greenlet>=3.0.0rc3')
-    else:
-        install_requires.append('greenlet')
+    install_requires.append('greenlet>=3.0')
 
 if sys.version_info < (3, 8):
     install_requires.append('typing-extensions')


### PR DESCRIPTION
Greenlet 3.0 has been released including full python 3.12 support. It
also works well with older python versions, so we can now have the
dependency `greenlet >= 3.0`.
