### PR TITLE
Fix broken tests on Windows due to EOF error and other minor bugs

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -27,37 +27,31 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ['3.10', '3.11', '3.12-dev']
+        python-version: ['3.12', '3.11', '3.10', '3.9', '3.8', '3.7']
         os: ['ubuntu-latest', 'macos-latest', 'windows-latest']
+        exclude:
+          - os: 'ubuntu-latest'
+            python-version: '3.7'
         include:
-        - os: ubuntu-20.04
-          python-version: '3.7'
-          NIGHTLY: nvim-linux64.tar.gz
-          NVIM_BIN_PATH: nvim-linux64/bin
-          EXTRACT: tar xzf
-        - os: ubuntu-latest
-          python-version: '3.8'
-          NIGHTLY: nvim-linux64.tar.gz
-          NVIM_BIN_PATH: nvim-linux64/bin
-          EXTRACT: tar xzf
-        - os: ubuntu-latest
-          python-version: '3.9'
-          NIGHTLY: nvim-linux64.tar.gz
-          NVIM_BIN_PATH: nvim-linux64/bin
-          EXTRACT: tar xzf
-        - os: ubuntu-latest
-          NIGHTLY: nvim-linux64.tar.gz
-          NVIM_BIN_PATH: nvim-linux64/bin
-          EXTRACT: tar xzf
-        - os: macos-latest
-          NIGHTLY: nvim-macos.tar.gz
-          NVIM_BIN_PATH: nvim-macos/bin
-          EXTRACT: tar xzf
-        - os: windows-latest
-          NIGHTLY: nvim-win64.zip
-          NVIM_BIN_PATH: nvim-win64/bin
-          EXTRACT: unzip
+          - os: 'ubuntu-20.04'
+            python-version: '3.7'
+            NIGHTLY: nvim-linux64.tar.gz
+            NVIM_BIN_PATH: nvim-linux64/bin
+            EXTRACT: tar xzf
+          - os: 'ubuntu-latest'
+            NIGHTLY: nvim-linux64.tar.gz
+            NVIM_BIN_PATH: nvim-linux64/bin
+            EXTRACT: tar xzf
+          - os: 'macos-latest'
+            NIGHTLY: nvim-macos.tar.gz
+            NVIM_BIN_PATH: nvim-macos/bin
+            EXTRACT: tar xzf
+          - os: 'windows-latest'
+            NIGHTLY: nvim-win64.zip
+            NVIM_BIN_PATH: nvim-win64/bin
+            EXTRACT: unzip
 
+    name: "test (python ${{ matrix.python-version }}, ${{ matrix.os }})"
     runs-on: ${{ matrix.os }}
     steps:
     - uses: actions/checkout@v3
@@ -65,12 +59,6 @@ jobs:
       with:
         cache: 'pip'
         python-version: ${{ matrix.python-version }}
-
-    - name: install neovim
-      run: |
-        curl -LO 'https://github.com/neovim/neovim/releases/download/nightly/${{ matrix.NIGHTLY }}'
-        ${{ matrix.EXTRACT }} ${{ matrix.NIGHTLY }}
-        echo '${{ runner.os }}'
 
     - name: update path (bash)
       if: runner.os != 'Windows'
@@ -80,16 +68,27 @@ jobs:
       if: runner.os == 'Windows'
       run: echo "$(pwd)/${{ matrix.NVIM_BIN_PATH }}" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
 
+    - name: install neovim
+      run: |
+        curl -LO 'https://github.com/neovim/neovim/releases/download/nightly/${{ matrix.NIGHTLY }}'
+        ${{ matrix.EXTRACT }} ${{ matrix.NIGHTLY }}
+        echo '${{ runner.os }}'
+        nvim --version
+
     - name: install dependencies
       run: |
         python3 -m pip install -U pip
         python3 -m pip install tox tox-gh-actions
 
+    - name: check neovim
+      run: |
+        python3 -m pip install -e .   # install pynvim
+        nvim --headless --clean -c 'checkhealth | %+print | q'
+
     - name: test with tox
       run: |
         echo $PATH
         which nvim
-        nvim --version
         which -a python3
         python3 --version
         tox run

--- a/pynvim/msgpack_rpc/event_loop/asyncio.py
+++ b/pynvim/msgpack_rpc/event_loop/asyncio.py
@@ -60,12 +60,17 @@ class AsyncioEventLoop(BaseEventLoop, asyncio.Protocol,
 
     def pipe_connection_lost(self, fd, exc):
         """Used to signal `asyncio.SubprocessProtocol` of a lost connection."""
+        debug("pipe_connection_lost: fd = %s, exc = %s", fd, exc)
+        if os.name == 'nt' and fd == 2:  # stderr
+            # On windows, ignore piped stderr being closed immediately (#505)
+            return
         self._on_error(exc.args[0] if exc else 'EOF')
 
     def pipe_data_received(self, fd, data):
         """Used to signal `asyncio.SubprocessProtocol` of incoming data."""
         if fd == 2:  # stderr fd number
-            self._on_stderr(data)
+            # Ignore stderr message, log only for debugging
+            debug("stderr: %s", str(data))
         elif self._on_data:
             self._on_data(data)
         else:

--- a/test/test_host.py
+++ b/test/test_host.py
@@ -11,15 +11,19 @@ __PATH__ = os.path.abspath(os.path.dirname(__file__))
 
 def test_host_imports(vim):
     h = ScriptHost(vim)
-    assert h.module.__dict__['vim']
-    assert h.module.__dict__['vim'] == h.legacy_vim
-    assert h.module.__dict__['sys']
+    try:
+        assert h.module.__dict__['vim']
+        assert h.module.__dict__['vim'] == h.legacy_vim
+        assert h.module.__dict__['sys']
+    finally:
+        h.teardown()
 
 
 def test_host_import_rplugin_modules(vim):
     # Test whether a Host can load and import rplugins (#461).
     # See also $VIMRUNTIME/autoload/provider/pythonx.vim.
     h = Host(vim)
+
     plugins: Sequence[str] = [  # plugin paths like real rplugins
         os.path.join(__PATH__, "./fixtures/simple_plugin/rplugin/python3/simple_nvim.py"),
         os.path.join(__PATH__, "./fixtures/module_plugin/rplugin/python3/mymodule/"),
@@ -56,7 +60,10 @@ def test_host_async_error(vim):
 
 def test_legacy_vim_eval(vim):
     h = ScriptHost(vim)
-    assert h.legacy_vim.eval('1') == '1'
-    assert h.legacy_vim.eval('v:null') is None
-    assert h.legacy_vim.eval('v:true') is True
-    assert h.legacy_vim.eval('v:false') is False
+    try:
+        assert h.legacy_vim.eval('1') == '1'
+        assert h.legacy_vim.eval('v:null') is None
+        assert h.legacy_vim.eval('v:true') is True
+        assert h.legacy_vim.eval('v:false') is False
+    finally:
+        h.teardown()

--- a/test/test_vim.py
+++ b/test/test_vim.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 import os
 import tempfile
 from typing import Any
@@ -31,7 +30,10 @@ def test_command(vim: Nvim) -> None:
     assert os.path.isfile(fname)
     with open(fname) as f:
         assert f.read() == 'testing\npython\napi\n'
-    os.unlink(fname)
+    try:
+        os.unlink(fname)
+    except OSError:
+        pass  # on windows, this can be flaky; ignore it
 
 
 def test_command_output(vim: Nvim) -> None:

--- a/tox.ini
+++ b/tox.ini
@@ -29,8 +29,10 @@ deps =
 # setenv =
 #   cov: PYTEST_ADDOPTS=--cov=. {env:PYTEST_ADDOPTS:}
 # passenv = PYTEST_ADDOPTS
+
+# Note: Use python instead of python3 due to tox-dev/tox#2801
 commands =
-  python3 -m pytest --color yes -s -vv {posargs}
+  python -m pytest --color yes -s --timeout 5 -vv {posargs}
 
 [testenv:checkqa]
 deps =


### PR DESCRIPTION
🎉✅ *TESTS on WINDOWS ARE NOW ALL GREEN* ✅🎉

Note: This PR consists of several commits and bugfixes, each of which is all required to fix the broken tests on windows platform for such a long time. I would like to request @justinmk that please merge this PR **without squashing** (either merge commit or rebasing), retaining all the individual commits.


## fix: EOF error on piped stderr being closed on Windows 

Most importantly, this PR should fix #505. Pipe (subprocess) based pynvim was broken since neovim 0.5.0, probably due to https://github.com/neovim/neovim/commit/c86d5fa981b0651167f789aaff685b42cad7aaca (neovim/neovim#11390): on Windows, stderr is closed for an embedded nvim.

See the commit message for more details.

## fix: do not leak resources across tests so as to prevent side effects

See the commit message for more details. asyncio event loops were not closing properly during tests, and were leaking in subsequent EventLoop, Session, Nvim instances.