### PR TITLE
fix: invalid CLI use in scripts/{enable,disable}_log_statements.sh

### DIFF
--- a/scripts/disable_log_statements.sh
+++ b/scripts/disable_log_statements.sh
@@ -1,4 +1,9 @@
-#!/bin/sh -e
+#!/bin/bash
+
+set -e
 
 cd pynvim
-find -name '*.py' | xargs -i{} ../scripts/logging_statement_modifier.py {}
+for f in $(find . -name '*.py'); do
+    echo "Processing: $f"
+    ../scripts/logging_statement_modifier.py "$f"
+done

--- a/scripts/enable_log_statements.sh
+++ b/scripts/enable_log_statements.sh
@@ -1,4 +1,9 @@
-#!/bin/sh -e
+#!/bin/bash
+
+set -e
 
 cd pynvim
-find -name '*.py' | xargs -i{} ../scripts/logging_statement_modifier.py --restore {}
+for f in $(find . -name '*.py'); do
+    echo "Processing: $f"
+    ../scripts/logging_statement_modifier.py --restore "$f"
+done

--- a/scripts/logging_statement_modifier.py
+++ b/scripts/logging_statement_modifier.py
@@ -66,7 +66,7 @@ PASS_LINE_CONTENTS = 'pass # replaces next logging statement\n'
 # include the whitespace, the logging method called, and the first argument if
 # possible
 RE_LOGGING_START = re.compile(r'^(\s+)' + STR_RE_LOGGING_CALL)
-RE_LOGGING_START_IN_COMMENT = re.compile(r'^(\s+)#' + STR_RE_LOGGING_CALL)
+RE_LOGGING_START_IN_COMMENT = re.compile(r'^(\s+)# ' + STR_RE_LOGGING_CALL)
 
 def main(argv=sys.argv[1:]):
     """Parses the command line comments."""
@@ -128,11 +128,11 @@ def comment_lines(lines):
     ret = []
     for line in lines:
         ws_prefix, rest, ignore = RE_LINE_SPLITTER_COMMENT.match(line).groups()
-        ret.append(ws_prefix + '#' + rest)
+        ret.append(ws_prefix + '# ' + rest)
     return ''.join(ret)
 
 # matches two main groups: 1) leading whitespace and 2) all following text
-RE_LINE_SPLITTER_UNCOMMENT = re.compile(r'^(\s*)#((.|\n)*)$')
+RE_LINE_SPLITTER_UNCOMMENT = re.compile(r'^(\s*)# ((.|\n)*)$')
 def uncomment_lines(lines):
     """Uncomment the given list of lines and return them.  The first hash mark
     following any amount of whitespace will be removed on each line."""


### PR DESCRIPTION
- `find -name` => `find . -name`
- `xargs -i` => `xargs -I` (or can be replaced by the for loop)
- Use bash for loop instead of xargs to abort early when erorr happens
- Have one whitespace after `#` in the comments to conform with the
  standard python code style

(should the commit message be prefixed with `packaging:` or `fix:` ?)