### PR TITLE
test: always use the same exact python executable regardless of $PATH

### DIFF
--- a/test/conftest.py
+++ b/test/conftest.py
@@ -3,6 +3,7 @@
 import gc
 import json
 import os
+import sys
 from typing import Generator
 
 import pytest
@@ -26,7 +27,8 @@ def vim() -> Generator[pynvim.Nvim, None, None]:
             "-n",  # no swap file
             "--embed",
             "--headless",
-            "-c", "let g:python3_host_prog='python3'",  # workaround neovim/neovim#25316
+            # Always use the same exact python executable regardless of $PATH
+            "--cmd", f"let g:python3_host_prog='{sys.executable}'",
         ])
 
     if child_argv is not None:

--- a/test/test_vim.py
+++ b/test/test_vim.py
@@ -1,6 +1,7 @@
 import os
+import sys
 import tempfile
-from typing import Any
+from pathlib import Path
 
 import pytest
 
@@ -199,15 +200,25 @@ def test_hash(vim: Nvim) -> None:
     assert d[vim.current.buffer] == 'beta'
 
 
-def test_python3(vim: Nvim, tmpdir: Any) -> None:
+def test_python3(vim: Nvim) -> None:
+    """Tests whether python3 host can load."""
     python3_prog = vim.command_output('echom provider#python3#Prog()')
     python3_err = vim.command_output('echom provider#python3#Error()')
     assert python3_prog != "", python3_err
+    assert python3_prog == sys.executable
 
+    assert sys.executable == vim.command_output(
+        'python3 import sys; print(sys.executable)')
+
+    assert 1 == vim.eval('has("python3")')
+
+
+def test_python_cwd(vim: Nvim, tmp_path: Path) -> None:
     vim.command('python3 import os')
     cwd_before = vim.command_output('python3 print(os.getcwd())')
 
-    vim.command('cd {}'.format(tmpdir.strpath))
+    # handle DirChanged #296
+    vim.command('cd {}'.format(str(tmp_path)))
     cwd_vim = vim.command_output('pwd')
     cwd_python = vim.command_output('python3 print(os.getcwd())')
     assert cwd_python == cwd_vim


### PR DESCRIPTION
Problem:
The embedded neovim fixture instance for testing picks up `python3`
on the `$PATH`. This can be different from the current python.

(Example)

    $ which python3
    /usr/local/bin/python3
    $ which python3.11
    $HOME/.pyenvs/versions/3.11.5/bin/python3.11

    $ python3.11 -m pytest

then neovim will have `/usr/local/bin/python3` as the python3 host,
so the behavior of `:python` (and `pynvim` especially when it has local
changes during development) can be different.

Solution:
The embedded nvim instance should always pin `g:python3_host_prog` to
`sys.executable`.
