### PR TITLE
feat: Ex command `:py=` evaluate and print python expression 

### DIFF
--- a/pynvim/msgpack_rpc/session.py
+++ b/pynvim/msgpack_rpc/session.py
@@ -243,12 +243,12 @@ class Session(object):
                       + 'sending %s as response', gr, rv)
                 response.send(rv)
             except ErrorResponse as err:
-                warn("error response from request '%s %s': %s", name,
-                     args, format_exc())
+                debug("error response from request '%s %s': %s",
+                      name, args, format_exc())
                 response.send(err.args[0], error=True)
             except Exception as err:
-                warn("error caught while processing request '%s %s': %s", name,
-                     args, format_exc())
+                warn("error caught while processing request '%s %s': %s",
+                     name, args, format_exc())
                 response.send(repr(err) + "\n" + format_exc(5), error=True)
             debug('greenlet %s is now dying...', gr)
 

--- a/pynvim/plugin/script_host.py
+++ b/pynvim/plugin/script_host.py
@@ -82,7 +82,7 @@ class ScriptHost(object):
         """Handle the `python` ex command."""
         self._set_current_range(range_start, range_stop)
 
-        if script[0] == '=':
+        if script.startswith('='):
             # Handle ":py= ...". Evaluate as an expression and print.
             # (note: a valid python statement can't start with "=")
             expr = script[1:]

--- a/pynvim/plugin/script_host.py
+++ b/pynvim/plugin/script_host.py
@@ -81,10 +81,19 @@ class ScriptHost(object):
     def python_execute(self, script, range_start, range_stop):
         """Handle the `python` ex command."""
         self._set_current_range(range_start, range_stop)
+
+        if script[0] == '=':
+            # if starts with '=', evaluated as an expression and printed.
+            # (note: a valid python statement can't start with "=")
+            expr = script[1:]
+            print(self.python_eval(expr))
+            return
+
         try:
+            # pylint: disable-next=exec-used
             exec(script, self.module.__dict__)
-        except Exception:
-            raise ErrorResponse(format_exc_skip(1))
+        except Exception as exc:
+            raise ErrorResponse(format_exc_skip(1)) from exc
 
     @rpc_export('python_execute_file', sync=True)
     def python_execute_file(self, file_path, range_start, range_stop):
@@ -93,9 +102,10 @@ class ScriptHost(object):
         with open(file_path, 'rb') as f:
             script = compile(f.read(), file_path, 'exec')
             try:
+                # pylint: disable-next=exec-used
                 exec(script, self.module.__dict__)
-            except Exception:
-                raise ErrorResponse(format_exc_skip(1))
+            except Exception as exc:
+                raise ErrorResponse(format_exc_skip(1)) from exc
 
     @rpc_export('python_do_range', sync=True)
     def python_do_range(self, start, stop, code):
@@ -154,7 +164,11 @@ class ScriptHost(object):
     @rpc_export('python_eval', sync=True)
     def python_eval(self, expr):
         """Handle the `pyeval` vim function."""
-        return eval(expr, self.module.__dict__)
+        try:
+            # pylint: disable-next=eval-used
+            return eval(expr, self.module.__dict__)
+        except Exception as exc:
+            raise ErrorResponse(format_exc_skip(1)) from exc
 
     @rpc_export('python_chdir', sync=False)
     def python_chdir(self, cwd):

--- a/pynvim/plugin/script_host.py
+++ b/pynvim/plugin/script_host.py
@@ -83,7 +83,7 @@ class ScriptHost(object):
         self._set_current_range(range_start, range_stop)
 
         if script[0] == '=':
-            # if starts with '=', evaluated as an expression and printed.
+            # Handle ":py= ...". Evaluate as an expression and print.
             # (note: a valid python statement can't start with "=")
             expr = script[1:]
             print(self.python_eval(expr))


### PR DESCRIPTION
The Ex command `:py`, `:python`, :`py3`, etc. can evaluate the line as an expression rather than a statement if the line starts with `=`, just like `:lua=`.

`:py= <expr>` is equivalent as `:py print(<expr>)`.

```vim
:py3= sys.version_info[:3]
:python3 =pynvim.__version__
```

## TODO

- How to document into `/doc/if_pyth.txt` (neovim core)? The feature would require pynvim 0.5.0 (or devel). It would make sense to submit a PR to neovim core only after a stable release of pynvim that contains this patch is released.


## Developer note:

~~should be merged (or rebased) after #547 to avoid conflicts~~ (Merged)