### PR TITLE
Pynvim 0.5.0

### DIFF
--- a/pynvim/_version.py
+++ b/pynvim/_version.py
@@ -4,7 +4,7 @@
 from types import SimpleNamespace
 
 # see also setup.py
-VERSION = SimpleNamespace(major=0, minor=5, patch=0, prerelease="dev0")
+VERSION = SimpleNamespace(major=0, minor=5, patch=0, prerelease="")
 
 # e.g. "0.5.0", "0.5.0.dev0" (PEP-440)
 __version__ = '{major}.{minor}.{patch}'.format(**vars(VERSION))


### PR DESCRIPTION
Breaking: Python 3.7 is the minimum supported Python version.

Changes since 0.4.3:

- 1696737 feat: Ex command ":py=" evaluate and print expression
- 86cc50e test: always use the same python regardless of $PATH
- 71d2d65 packaging: Add pynvim.__version__ attribute
- 056f6f9 fix: ignore flaky OSError on windows
- 6ab90aa fix: EOF error on piped stderr being closed on Windows
- fd4247c fix: do not leak resources across tests so as to prevent side effects
- 260a0b9 deps: Require greenlet >= 3.0 since it supports Python 3.12
- f244597 fix: broken dynamic import of rplugin modules
- e4224fc fix: sphinx "invalid language code"
- 61bf6fa fix: mypy type annotation warnings
- 5e84c75 fix: sphinx "Unexpected indentation" warning
- 991c689 fix: PEP 484 prohibits implicit Optional
- 919217d fix: undefined name 'original_find_module'
- b79717f fix(test): `Unknown config option: timeout` warning
- 5be54e2 test_buffer: don't depend on version-dependent default values
- eaa862d fix: imp module is deprecated
- ac03f5c Drop old python versions, add type annotations
- a087534 docs: python 2 is not supported
- 82a2e14 test: update 'define' option default
- dd540b0 refactor: remove usage of imp
- 496e8eb packaging: conform to PEP 517 guidelines
- d549371 fix: vim.eval('v:true') should return python bool
- 318c1b5 fix the first call to sync functions returning null
