### PR TITLE
ci: fix failing readthedocs build by adding sphinx_rtd_theme dependency

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -17,6 +17,8 @@ sphinx:
   fail_on_warning: true
 
 python:
-   install:
-   - method: pip
-     path: .
+  install:
+  - method: pip
+    path: .
+    extra_requirements:
+      - sphinx_rtd_theme


### PR DESCRIPTION
This *might* fix the failing readthedocs CI #552 issue (can't fully test until merged).