### PR TITLE
refactor: remove the use of forward references

### DIFF
--- a/pynvim/api/buffer.py
+++ b/pynvim/api/buffer.py
@@ -1,4 +1,7 @@
 """API for working with a Nvim Buffer."""
+
+from __future__ import annotations
+
 from typing import (Any, Iterator, List, Optional, TYPE_CHECKING, Tuple, Union, cast,
                     overload)
 
@@ -44,7 +47,7 @@ class Buffer(Remote):
     _api_prefix = "nvim_buf_"
     _session: "Nvim"
 
-    def __init__(self, session: "Nvim", code_data: Tuple[int, Any]):
+    def __init__(self, session: Nvim, code_data: Tuple[int, Any]):
         """Initialize from Nvim and code_data immutable object."""
         super().__init__(session, code_data)
 
@@ -150,7 +153,7 @@ class Buffer(Remote):
         """Return (row, col) tuple for a named mark."""
         return cast(Tuple[int, int], tuple(self.request('nvim_buf_get_mark', name)))
 
-    def range(self, start: int, end: int) -> "Range":
+    def range(self, start: int, end: int) -> Range:
         """Return a `Range` object, which represents part of the Buffer."""
         return Range(self, start, end)
 
@@ -245,7 +248,8 @@ class Buffer(Remote):
         return self.handle
 
 
-class Range(object):
+class Range:
+
     def __init__(self, buffer: Buffer, start: int, end: int):
         self._buffer = buffer
         self.start = start - 1

--- a/pynvim/api/common.py
+++ b/pynvim/api/common.py
@@ -80,8 +80,7 @@ class Remote(ABC):
         return self._session.request(name, self, *args, **kwargs)
 
 
-class RemoteApi(object):
-
+class RemoteApi:
     """Wrapper to allow api methods to be called like python methods."""
 
     def __init__(self, obj: IRemote, api_prefix: str):
@@ -106,7 +105,7 @@ def transform_keyerror(exc: E) -> Union[E, KeyError]:
     return exc
 
 
-class RemoteMap(object):
+class RemoteMap:
     """Represents a string->object map stored in Nvim.
 
     This is the dict counterpart to the `RemoteSequence` class, but it is used

--- a/pynvim/api/nvim.py
+++ b/pynvim/api/nvim.py
@@ -1,5 +1,7 @@
 """Main Nvim interface."""
 
+from __future__ import annotations
+
 import asyncio
 import os
 import sys
@@ -56,8 +58,7 @@ _G["_pynvim_"..chid] = mod
 """
 
 
-class Nvim(object):
-
+class Nvim:
     """Class that represents a remote Nvim instance.
 
     This class is main entry point to Nvim remote API, it is a wrapper
@@ -81,7 +82,7 @@ class Nvim(object):
     """
 
     @classmethod
-    def from_session(cls, session: 'Session') -> 'Nvim':
+    def from_session(cls, session: Session) -> Nvim:
         """Create a new Nvim instance for a Session instance.
 
         This method must be called to create the first Nvim instance, since it
@@ -102,14 +103,14 @@ class Nvim(object):
         return cls(session, channel_id, metadata, types)
 
     @classmethod
-    def from_nvim(cls, nvim: 'Nvim') -> 'Nvim':
+    def from_nvim(cls, nvim: Nvim) -> Nvim:
         """Create a new Nvim instance from an existing instance."""
         return cls(nvim._session, nvim.channel_id, nvim.metadata,
                    nvim.types, nvim._decode, nvim._err_cb)
 
     def __init__(
         self,
-        session: 'Session',
+        session: Session,
         channel_id: int,
         metadata: Dict[str, Any],
         types: Dict[int, Any],
@@ -168,7 +169,7 @@ class Nvim(object):
             return ExtType(*obj.code_data)
         return obj
 
-    def _get_lua_private(self) -> 'LuaFuncs':
+    def _get_lua_private(self) -> LuaFuncs:
         if not getattr(self._session, "_has_lua", False):
             self.exec_lua(lua_module, self.channel_id)
             self._session._has_lua = True  # type: ignore[attr-defined]
@@ -269,7 +270,7 @@ class Nvim(object):
         """Close the nvim session and release its resources."""
         self._session.close()
 
-    def __enter__(self) -> 'Nvim':
+    def __enter__(self) -> Nvim:
         """Enter nvim session as a context manager."""
         return self
 
@@ -280,7 +281,7 @@ class Nvim(object):
         """
         self.close()
 
-    def with_decode(self, decode: Literal[True] = True) -> 'Nvim':
+    def with_decode(self, decode: Literal[True] = True) -> Nvim:
         """Initialize a new Nvim instance."""
         return Nvim(self._session, self.channel_id,
                     self.metadata, self.types, decode, self._err_cb)
@@ -575,8 +576,7 @@ class Current(object):
         return self._session.request('nvim_set_current_tabpage', tabpage)
 
 
-class Funcs(object):
-
+class Funcs:
     """Helper class for functional vimscript interface."""
 
     def __init__(self, nvim: Nvim):
@@ -586,15 +586,14 @@ class Funcs(object):
         return partial(self._nvim.call, name)
 
 
-class LuaFuncs(object):
-
+class LuaFuncs:
     """Wrapper to allow lua functions to be called like python methods."""
 
     def __init__(self, nvim: Nvim, name: str = ""):
         self._nvim = nvim
         self.name = name
 
-    def __getattr__(self, name: str) -> 'LuaFuncs':
+    def __getattr__(self, name: str) -> LuaFuncs:
         """Return wrapper to named api method."""
         prefix = self.name + "." if self.name else ""
         return LuaFuncs(self._nvim, prefix + name)

--- a/pynvim/api/tabpage.py
+++ b/pynvim/api/tabpage.py
@@ -1,8 +1,12 @@
 """API for working with Nvim tabpages."""
+
+from __future__ import annotations
+
 from typing import Any, TYPE_CHECKING, Tuple
 
 from pynvim.api.common import Remote, RemoteSequence
 from pynvim.api.window import Window
+
 if TYPE_CHECKING:
     from pynvim.api.nvim import Nvim
 
@@ -15,7 +19,7 @@ class Tabpage(Remote):
 
     _api_prefix = "nvim_tabpage_"
 
-    def __init__(self, session: 'Nvim', code_data: Tuple[int, Any]):
+    def __init__(self, session: Nvim, code_data: Tuple[int, Any]):
         """Initialize from session and code_data immutable object.
 
         The `code_data` contains serialization information required for

--- a/pynvim/api/window.py
+++ b/pynvim/api/window.py
@@ -1,4 +1,7 @@
 """API for working with Nvim windows."""
+
+from __future__ import annotations
+
 from typing import TYPE_CHECKING, Tuple, cast
 
 from pynvim.api.buffer import Buffer
@@ -63,7 +66,7 @@ class Window(Remote):
         return self.request('nvim_win_get_position')[1]
 
     @property
-    def tabpage(self) -> 'Tabpage':
+    def tabpage(self) -> Tabpage:
         """Get the `Tabpage` that contains the window."""
         return self.request('nvim_win_get_tabpage')
 

--- a/pynvim/msgpack_rpc/event_loop/asyncio.py
+++ b/pynvim/msgpack_rpc/event_loop/asyncio.py
@@ -1,5 +1,7 @@
 """Event loop implementation that uses the `asyncio` standard module."""
 
+from __future__ import annotations
+
 import asyncio
 import logging
 import os
@@ -91,7 +93,7 @@ class AsyncioEventLoop(BaseEventLoop):
     _signals: List[Signals]
     _data_buffer: Deque[bytes]
     if os.name != 'nt':
-        _child_watcher: Optional['asyncio.AbstractChildWatcher']
+        _child_watcher: Optional[asyncio.AbstractChildWatcher]
 
     def __init__(self,
                  transport_type: TTransportType,


### PR DESCRIPTION
With PEP-563 (Postponed evaluation of annotations), we can have a more
clean syntax of writing type hints, not using 'forward references' to
names that have not been defined yet in the form of string literals.

Note that Python 3.7+ (the minimum python version that is currently
supported by pynvim) supports PEP-563.
