### PR TITLE
Revert "fix: vim.eval('v:true') should return python bool #506"

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,9 @@ Pynvim defines some extensions over the vim python API:
 
 See the [Python Plugin API](http://pynvim.readthedocs.io/en/latest/usage/python-plugin-api.html) documentation for usage of this new functionality.
 
+### Known Issues
+- Vim evaluates `'v:<bool>'` to `<class 'bool'>`, whereas neovim evaluates to `<class 'str'>`. This is expected behaviour due to the way booleans are implemented in python as explained [here](https://github.com/neovim/pynvim/issues/523#issuecomment-1495502011).
+
 Development
 -----------
 

--- a/pynvim/plugin/script_host.py
+++ b/pynvim/plugin/script_host.py
@@ -195,7 +195,7 @@ num_types = (int, float)
 
 
 def num_to_str(obj):
-    if isinstance(obj, num_types) and not isinstance(obj, bool):
+    if isinstance(obj, num_types):
         return str(obj)
     else:
         return obj

--- a/test/test_host.py
+++ b/test/test_host.py
@@ -56,14 +56,3 @@ def test_host_async_error(vim):
     assert event[1] == 'nvim_error_event'
     assert 'rplugin-host: Async request caused an error:\nboom\n' \
            in h._on_error_event(None, 'boom')
-
-
-def test_legacy_vim_eval(vim):
-    h = ScriptHost(vim)
-    try:
-        assert h.legacy_vim.eval('1') == '1'
-        assert h.legacy_vim.eval('v:null') is None
-        assert h.legacy_vim.eval('v:true') is True
-        assert h.legacy_vim.eval('v:false') is False
-    finally:
-        h.teardown()


### PR DESCRIPTION
This reverts commit d549371b6fb647304cff5f88a71e2bc42d2ed30a. This fixes #523 and make UltiSnips usable. As mentioned by @jsr-p, the extra check is redundant and is not worth the slower performance.