### PR TITLE
fix: Remove deprecated alias of logger.warn

### DIFF
--- a/pynvim/plugin/script_host.py
+++ b/pynvim/plugin/script_host.py
@@ -16,7 +16,7 @@ __all__ = ('ScriptHost',)
 
 
 logger = logging.getLogger(__name__)
-debug, info, warn = (logger.debug, logger.info, logger.warn,)
+debug, info, warn = (logger.debug, logger.info, logger.warning,)
 
 
 @plugin


### PR DESCRIPTION
python-neovim fails to build with Python 3.13.0b1.

According to https://docs.python.org/3.13/whatsnew/3.13.html:

logging: Remove undocumented and untested Logger.warn() and LoggerAdapter.warn() methods and logging.warn() function.  Deprecated since Python 3.3, they were aliases to the logging.Logger.warning() method, logging.LoggerAdapter.warning() method and logging.warning() function.