### PR TITLE
fix(tests): remove reference to pytest-runner

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -13,10 +13,9 @@ install_requires = [
 ]
 
 needs_pytest = {'pytest', 'test', 'ptr'}.intersection(sys.argv)
-pytest_runner = ['pytest-runner'] if needs_pytest else []
 
 setup_requires = [
-] + pytest_runner
+]
 
 tests_require = [
     'pytest',


### PR DESCRIPTION
This does not seem to be used any longer.

Closes #572.