### PR TITLE
Pynvim 0.5.1

### DIFF
--- a/pynvim/_version.py
+++ b/pynvim/_version.py
@@ -4,7 +4,7 @@
 from types import SimpleNamespace
 
 # see also setup.py
-VERSION = SimpleNamespace(major=0, minor=5, patch=1, prerelease="dev0")
+VERSION = SimpleNamespace(major=0, minor=5, patch=1, prerelease="")
 
 # e.g. "0.5.0", "0.5.0.dev0" (PEP-440)
 __version__ = '{major}.{minor}.{patch}'.format(**vars(VERSION))


### PR DESCRIPTION
Changes since 0.5.0:

- 4813ce6 fix(tests): failing tests on python3.13 about stacktrace messages #578
- 9391eff docs: avoid deprecated $NVIM_LISTEN_ADDRESS env var #575
- 9fc77f0 fix(tests): remove reference to pytest-runner #573
- a855fa3 fix: deprecated alias of logger.warn #569
- cc45f5b fix(tests): broadcast test fails #570
- 4d65226 fix(ci): macOS CI fails with "Unrecognized archive format"
- d6dc8cf fix: UpdateRemotePlugins not finding specs on Windows #565
- 9f3e010 Revert "fix: vim.eval('v:true') should return python bool" #562
- f9d839f fix(tests): "provider#python3#Prog" was removed upstream #563
- 5f989df refactor: remove the use of forward references #558
- c4197f1 fix(ci): failing readthedocs build #554
- da0970e ci: fix failing readthedocs build
- 7a84048 fix(ci): failing readthedocs build #553
- e74a7f6 test: attaching via socket, tcp, stdio #544
- 17fbcbc fix: prevent closed pipe errors on closing asyncio transport resources
- 7f60f72 refactor: improve typing
- 3f5f532 refactor: separate asyncio Protocol from AsyncioEventLoop
- 2059684 refactor: use async coroutine and add debugging statements
- be5810b refactor: expose event loop as a property rather than a field
- a1347ee refactor!: completely wipe out pyuv