### PR TITLE
build: fix conditional `install_requires`

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -10,6 +10,8 @@ from setuptools import setup
 
 install_requires = [
     'msgpack>=0.5.0',
+    'greenlet>=3.0; python_implementation != "PyPy"',
+    'typing-extensions>=4.5; python_version < "3.12"',
 ]
 
 needs_pytest = {'pytest', 'test', 'ptr'}.intersection(sys.argv)
@@ -31,13 +33,6 @@ extras_require = {
     'test': tests_require,
     'docs': docs_require,
 }
-
-if platform.python_implementation() != 'PyPy':
-    # pypy already includes an implementation of the greenlet module
-    install_requires.append('greenlet>=3.0')
-
-if sys.version_info < (3, 12):
-    install_requires.append('typing-extensions>=4.5')
 
 
 # __version__: see pynvim/_version.py


### PR DESCRIPTION
Fix conditional `install_requires` in `setup.py` to use environment markers instead of inline conditions.  The latter do not work correctly with universal wheels -- e.g. a wheel made on Python 3.12 would not have a dependency on `typing-extensions` at all, even if it were installed on Python 3.11 or older, and the other way around.