### PR TITLE
ci: improve build matrix configuration, test with python3.13 and neovim-stable as well

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -28,7 +28,9 @@ jobs:
       fail-fast: false
       matrix:
         config: [
-          { python-version: '3.12' },
+          { python-version: '3.13', neovim-version: 'nightly' },
+          { python-version: '3.12', neovim-version: 'nightly' },
+          { python-version: '3.12', neovim-version: 'stable' },
           { python-version: '3.11' },
           { python-version: '3.10' },
           # for python 3.7~3.9, use older version of OS (ubuntu-20.04 and macos-12)
@@ -38,10 +40,11 @@ jobs:
         ]
         os: ['ubuntu', 'macos', 'windows']
 
-    runs-on: ${{ matrix.os }}-${{ matrix.config[matrix.os] || 'latest' }}
     name:
       test (python ${{ matrix.config.python-version }},
+            ${{ matrix.config.neovim-version || 'nightly' }},
             ${{ matrix.os }}-${{ matrix.config[matrix.os] || 'latest' }})
+    runs-on: ${{ matrix.os }}-${{ matrix.config[matrix.os] || 'latest' }}
     steps:
     - uses: actions/checkout@v3
     - uses: actions/setup-python@v4
@@ -62,7 +65,7 @@ jobs:
           echo "$RUNNER_OS not supported"; exit 1;
         fi
 
-        curl -LO "https://github.com/neovim/neovim/releases/download/nightly/${BASE}.tar.gz"
+        curl -LO "https://github.com/neovim/neovim/releases/download/${{ matrix.config.neovim-version || 'nightly' }}/${BASE}.tar.gz"
         tar xzf "${BASE}.tar.gz"
         echo "RUNNER_OS = $RUNNER_OS"
         $BASE/bin/nvim --version

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -27,35 +27,27 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ['3.12', '3.11', '3.10', '3.9', '3.8', '3.7']
-        os: ['ubuntu-latest', 'macos-latest', 'windows-latest']
-        exclude:
-          - os: 'ubuntu-latest'
-            python-version: '3.7'
-          - os: 'macos-latest'
-            python-version: '3.7'
-          - os: 'macos-latest'
-            python-version: '3.8'
-          - os: 'macos-latest'
-            python-version: '3.9'
-        include:
-          - os: 'ubuntu-20.04'
-            python-version: '3.7'
-          - os: 'macos-12'
-            python-version: '3.7'
-          - os: 'macos-12'
-            python-version: '3.8'
-          - os: 'macos-12'
-            python-version: '3.9'
+        config: [
+          { python-version: '3.12' },
+          { python-version: '3.11' },
+          { python-version: '3.10' },
+          # for python 3.7~3.9, use older version of OS (ubuntu-20.04 and macos-12)
+          { python-version: '3.9', ubuntu: '20.04', macos: '13' },
+          { python-version: '3.8', ubuntu: '20.04', macos: '13' },
+          { python-version: '3.7', ubuntu: '20.04', macos: '13' },
+        ]
+        os: ['ubuntu', 'macos', 'windows']
 
-    name: "test (python ${{ matrix.python-version }}, ${{ matrix.os }})"
-    runs-on: ${{ matrix.os }}
+    runs-on: ${{ matrix.os }}-${{ matrix.config[matrix.os] || 'latest' }}
+    name:
+      test (python ${{ matrix.config.python-version }},
+            ${{ matrix.os }}-${{ matrix.config[matrix.os] || 'latest' }})
     steps:
     - uses: actions/checkout@v3
     - uses: actions/setup-python@v4
       with:
         cache: 'pip'
-        python-version: ${{ matrix.python-version }}
+        python-version: ${{ matrix.config.python-version }}
 
     - name: install neovim (Linux/macOS)
       if: runner.os != 'Windows'

--- a/test/test_events.py
+++ b/test/test_events.py
@@ -1,4 +1,5 @@
-# -*- coding: utf-8 -*-
+import pytest
+
 from pynvim.api import Nvim
 
 
@@ -37,6 +38,10 @@ def test_async_error(vim: Nvim) -> None:
 
 
 def test_broadcast(vim: Nvim) -> None:
+    if (vim.version.major, vim.version.minor) < (0, 11):
+        # see #570, neovim/neovim#28487
+        pytest.skip("neovim/neovim#28487")
+
     vim.command('call rpcnotify(0, "event1", 1, 2, 3)')
     vim.command('call rpcnotify(0, "event2", 4, 5, 6)')
     vim.command('call rpcnotify(0, "event2", 7, 8, 9)')


### PR DESCRIPTION
- ci: improve build matrix configuration
- fix(tests): skip failing test_broadcast on neovim < 0.11
- ci: add more configurations (python3.13, neovim-version='stable') 

Note: Tests are still failing on nvim-nightly due to upstream bug, but as soon as https://github.com/neovim/neovim/issues/31894 is fixed it should be back to green.