### PR TITLE
fix(test_connect_stdio): invoke python3 instead of python

### DIFF
--- a/test/test_attach.py
+++ b/test/test_attach.py
@@ -125,7 +125,7 @@ def test_connect_stdio(vim: Nvim) -> None:
     ])
     # see :help jobstart(), *jobstart-options* |msgpack-rpc|
     jobid = vim.funcs.jobstart([
-        'python', '-c', remote_py_code,
+        'python3', '-c', remote_py_code,
     ], {'rpc': True, 'on_stderr': 'OutputHandler'})
     assert jobid > 0
     exitcode = vim.funcs.jobwait([jobid], 500)[0]


### PR DESCRIPTION
"python" is the name for Python 2's interpreter. Since pynvim is now
Python 3 only, there's no reason to expect the legacy interpreter to be
available.