### PR TITLE
fix: return python interpreter exit status from pynvim-python

### DIFF
--- a/pynvim/python.py
+++ b/pynvim/python.py
@@ -25,4 +25,4 @@ import sys
 
 def main() -> None:
     """Chain to Python interpreter, passing all command-line args."""
-    subprocess.run([sys.executable] + sys.argv[1:])
+    sys.exit(subprocess.run([sys.executable] + sys.argv[1:]).returncode)


### PR DESCRIPTION
Problem: python interpreter exit status is ignored by pynvim-python.

For example:

```console
$ pynvim-python -c 'import sys; sys.exit(5)'; echo $?
0
```

Solution: propagate the exit status from pynvim-python.

Use `sys.exit()` to return the interpreter's exit status as found in `subprocess.run().returncode`:

```console
$ pynvim-python -c 'import sys; sys.exit(5)'; echo $?
5
```

Despite the number of times I read over this code, I'm sorry to say I failed to notice the expected `sys.exit()` was missing.  This week, I woke from a sound sleep in the middle of the night with the thought that I didn't remember seeing `sys.exit()`; I got up to check, and sure enough I'd left it off.
