### PR TITLE
test: unreliable "test_connect_stdio"

### DIFF
--- a/test/test_attach.py
+++ b/test/test_attach.py
@@ -128,7 +128,7 @@ def test_connect_stdio(vim: Nvim) -> None:
         'python3', '-c', remote_py_code,
     ], {'rpc': True, 'on_stderr': 'OutputHandler'})
     assert jobid > 0
-    exitcode = vim.funcs.jobwait([jobid], 500)[0]
+    exitcode = vim.funcs.jobwait([jobid], 5000)[0]
     messages = vim.command_output('messages')
     assert exitcode == 0, ("the python process failed, :messages =>\n\n" +
                            messages)


### PR DESCRIPTION
Problem:
test_connect_stdio is flaky because jobwait has a 500ms timeout, which can expire on slow CI before the subprocess finishes importing pynvim and attaching via stdio.

Solution:
Increase the jobwait timeout to 5000ms.